### PR TITLE
Graph: Add functions to return ConstantOps and VariableOps

### DIFF
--- a/catamount/graph/__init__.py
+++ b/catamount/graph/__init__.py
@@ -1,5 +1,6 @@
 from catamount.ops.base_op import Op
 from catamount.ops.subgraph_op import SubgraphOp
+from catamount.ops.constant import ConstantOp
 from catamount.ops.placeholder import PlaceholderOp
 from catamount.ops.variable import VariableOp
 
@@ -41,10 +42,24 @@ class Graph(SubgraphOp):
         _catamount_default_graph = self
         return ctx_mgr
 
+    def getConstants(self):
+        to_return = []
+        for op in self._ops_by_name.values():
+            if isinstance(op, ConstantOp):
+                to_return.append(op)
+        return to_return
+
     def getPlaceholders(self):
         to_return = []
         for op in self._ops_by_name.values():
             if isinstance(op, PlaceholderOp):
+                to_return.append(op)
+        return to_return
+
+    def getVariables(self):
+        to_return = []
+        for op in self._ops_by_name.values():
+            if isinstance(op, VariableOp):
                 to_return.append(op)
         return to_return
 


### PR DESCRIPTION
When hacking on a graph, these functions are very convenient for gathering
the ops that we would like to propagate shapes from (much like the
getPlaceholders function).