### PR TITLE
L2LossOp: Add implementation

### DIFF
--- a/catamount/frameworks/tensorflow.py
+++ b/catamount/frameworks/tensorflow.py
@@ -95,6 +95,7 @@ TF_OP_TO_CATAMOUNT = {
     'LogicalOr': LogicalOrOp,
     'LogicalNot': LogicalNotOp,
     'LoopCond': LoopConditionOp,
+    'L2Loss': L2LossOp,
     'MatMul': MatMulOp,
     'Max': ReduceOp,
     'Maximum': MaximumOp,
@@ -188,7 +189,6 @@ TF_OP_TO_CATAMOUNT_REDUCE = {
 
 # TODO (Joel): Prioritize these ops:
 # -- NMT
-# L2Loss
 # -- Speech
 # -- Others
 

--- a/catamount/ops/loss_ops.py
+++ b/catamount/ops/loss_ops.py
@@ -30,6 +30,28 @@ class InTopKOp(Op):
         return self.bytesAccessOutput()
 
 
+class L2LossOp(Op):
+    ''' Computes half the L2 norm of a tensor without the sqrt:
+        output = sum(t ** 2) / 2
+    '''
+    def __init__(self, name):
+        super(L2LossOp, self).__init__(name)
+
+    def propagateShapes(self, make_symbolic=False):
+        self.debugAssert(len(self._inputs) == 1)
+        self.debugAssert(len(self._outputs) == 1)
+        # Output shape should be a scalar value. No need for make_symbolic
+        # since shape cannot be symbolic
+        self._outputs[0].shape.mergeShape([])
+
+    def calcAlgFlops(self):
+        self.debugAssert(len(self._inputs) == 1)
+        self.debugAssert(len(self._outputs) == 1)
+        # 2 Flops per element (square and accumulate) and a final divide
+        total_flops = 2 * self._outputs[0].shape.numElements() + 1
+        return total_flops
+
+
 class SparseSoftmaxCrossEntropyWithLogitsOp(Op):
     def __init__(self, name):
         super(SparseSoftmaxCrossEntropyWithLogitsOp, self).__init__(name)

--- a/catamount/ops/loss_ops.py
+++ b/catamount/ops/loss_ops.py
@@ -51,6 +51,13 @@ class L2LossOp(Op):
         total_flops = 2 * self._outputs[0].shape.numElements() + 1
         return total_flops
 
+    def calcAlgBytes(self):
+        return self.bytesAccessInput() + self.bytesAccessOutput()
+
+    def calcAlgFootprint(self):
+        # Return the size of the output tensor, which must be accessed
+        return self.bytesAccessOutput()
+
 
 class SparseSoftmaxCrossEntropyWithLogitsOp(Op):
     def __init__(self, name):

--- a/catamount/tests/full/tf_language_models.py
+++ b/catamount/tests/full/tf_language_models.py
@@ -587,26 +587,26 @@ def run_tf_language_model(domain=None, build_projection=False):
                                   8 * hidden_dim_symbol + \
                                   vocab_size_symbol + 2
         correct_params = 104378326
-        correct_flops = 2597058084236
-        correct_bytes = 143274390368
-        correct_total_footprint = 49660366844
+        correct_flops = 2597058084257
+        correct_bytes = 143652753548
+        correct_total_footprint = 49660366872
     elif domain == 'charlm':
         correct_symbolic_params = 22 * hidden_dim_symbol**2 + \
                                   2 * hidden_dim_symbol * vocab_size_symbol + \
                                   20 * hidden_dim_symbol + \
                                   vocab_size_symbol + 2
         correct_params = 88785316
-        correct_flops = 10228050930582
-        correct_bytes = 444794006008
-        correct_total_footprint = 156135667088
+        correct_flops = 10228050930711
+        correct_bytes = 445302269068
+        correct_total_footprint = 156135667260
     elif domain == 'nmt':
         correct_symbolic_params = 33 * hidden_dim_symbol**2 + \
                                   3 * hidden_dim_symbol * vocab_size_symbol + \
                                   12 * hidden_dim_symbol + 1
         correct_params = 146890753
-        correct_flops = 1053956094363
-        correct_bytes = 35992083787
-        correct_total_footprint = 14372109278
+        correct_flops = 1053956094429
+        correct_bytes = 36608253347
+        correct_total_footprint = 14372109366
     else:
         raise NotImplementedError('ERROR: Unknown domain: {}'.format(domain))
     assert sympy.simplify(parameters - correct_symbolic_params) == 0, \

--- a/catamount/tests/full/tf_speech_attention.py
+++ b/catamount/tests/full/tf_speech_attention.py
@@ -530,7 +530,7 @@ def run_tf_speech_attention():
     except:
         print('ERROR: resolved_flops should be int, but is {} = {}'.format(
               type(resolved_flops), resolved_flops))
-    correct_flops = 568344682777
+    correct_flops = 568344682852
     assert resolved_flops == correct_flops, \
            'Incorrect algorithmic flops: {}'.format(resolved_flops)
     print('Algorithmic Flops: {}\nWith specified dims: {}\n'.format(alg_flops, resolved_flops))
@@ -543,7 +543,7 @@ def run_tf_speech_attention():
     except:
         print('ERROR: resolved_bytes should be int, but is {} = {}'.format(
               type(resolved_bytes), resolved_bytes))
-    correct_bytes = 86482106889
+    correct_bytes = 86766445577
     assert resolved_bytes == correct_bytes, \
            'Incorrect algorithmic bytes: {}'.format(resolved_bytes)
     print('Alg bytes accessed: {}\nWith specified dims: {}\n'.format(alg_bytes, resolved_bytes))
@@ -556,7 +556,7 @@ def run_tf_speech_attention():
     except:
         print('ERROR: resolved_footprint should be int, but is {} = {}'.format(
               type(resolved_footprint), resolved_footprint))
-    correct_footprint = 30361128478
+    correct_footprint = 30361128578
     assert resolved_footprint == correct_footprint, \
            'Incorrect algorithmic footprint: {}'.format(resolved_footprint)
     print('Alg mem footprint: {}\nWith specified dims: {}\n'.format(alg_footprint, resolved_footprint))


### PR DESCRIPTION
One of the last ops that shows up frequently in many models is an L2 loss. This PR adds an implementation and updates tests that previously did not count the L2 loss op's compute requirements.