### PR TITLE
Graph: Refine tensor shape binding

### DIFF
--- a/catamount/graph/__init__.py
+++ b/catamount/graph/__init__.py
@@ -1,5 +1,6 @@
 import re
 from catamount.ops.base_op import Op
+from catamount.ops.constant import ConstantOp
 from catamount.ops.subgraph_op import SubgraphOp
 from catamount.ops.placeholder import PlaceholderOp
 from catamount.ops.variable import VariableOp

--- a/catamount/ops/active_ops.py
+++ b/catamount/ops/active_ops.py
@@ -29,8 +29,8 @@ class FusedBatchNormOp(FusedBatchNormBaseOp):
         self.debugAssert(len(self._inputs) == 5)
         self.debugAssert(len(self._outputs) == 5)
         # Input 0 is the batch values and should propagate to output 0
-        self._outputs[0].shape.mergeShape(self._inputs[0].shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(self._inputs[0].shape,
+                                    make_symbolic=make_symbolic)
         # Input 1 is the scale factor and input 2 is the offset, which
         # must have the same dimension
         scale_shape = self._inputs[1].shape
@@ -43,8 +43,8 @@ class FusedBatchNormOp(FusedBatchNormBaseOp):
         # represent the batch mean and variance for running values, and
         # batch mean and variance for the gradient
         for idx in range(1, 5):
-            self._outputs[idx].shape.mergeShape(scale_shape,
-                                                make_symbolic=make_symbolic)
+            self._outputs[idx].mergeShape(scale_shape,
+                                          make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._inputs) == 5)
@@ -88,14 +88,14 @@ class FusedBatchNormGradOp(FusedBatchNormBaseOp):
         grad_shape = self._inputs[0].shape
         x_shape = self._inputs[1].shape
         self.debugAssert(grad_shape == x_shape)
-        self._outputs[0].shape.mergeShape(x_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(x_shape,
+                                    make_symbolic=make_symbolic)
         # Input 2 is the input scaling factor, which should propagate shape
         # to outputs 1 and 2, the scale and offset gradients
-        self._outputs[1].shape.mergeShape(self._inputs[2].shape,
-                                          make_symbolic=make_symbolic)
-        self._outputs[2].shape.mergeShape(self._inputs[2].shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[1].mergeShape(self._inputs[2].shape,
+                                    make_symbolic=make_symbolic)
+        self._outputs[2].mergeShape(self._inputs[2].shape,
+                                    make_symbolic=make_symbolic)
         # TODO (Joel): May need to check shape of inputs 3, 4 for training
 
     def calcAlgFlops(self):

--- a/catamount/ops/array_ops.py
+++ b/catamount/ops/array_ops.py
@@ -44,11 +44,11 @@ class BroadcastGradientArgsOp(Op):
                     print('WARN: BroadcastGradientArgs op {}: Dimension[{}]' \
                           ' mismatch: {} {}'.format(self.name, idx,
                           in_0_val[idx], in_1_val[idx]))
-        self._outputs[0].shape.mergeShape([len(out_0_val)],
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape([len(out_0_val)],
+                                    make_symbolic=make_symbolic)
         self._outputs[0].setValue(out_0_val)
-        self._outputs[1].shape.mergeShape([len(out_1_val)],
-                                          make_symbolic=make_symbolic)
+        self._outputs[1].mergeShape([len(out_1_val)],
+                                    make_symbolic=make_symbolic)
         self._outputs[1].setValue(out_1_val)
 
     def calcAlgFlops(self):
@@ -85,8 +85,8 @@ class ConcatOp(Op):
             in_c_dim = in_shape.dims[axis]
             out_shape_c_dim += in_c_dim
             in_shape.dims[axis] = Dimension(None)
-            self._outputs[0].shape.mergeShape(in_shape,
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape(in_shape,
+                                        make_symbolic=make_symbolic)
         self._outputs[0].shape.setDimension(axis, out_shape_c_dim,
                                             make_symbolic=make_symbolic)
 
@@ -142,8 +142,8 @@ class ConcatOffsetOp(Op):
             return
         curr_axis_offset = 0
         for idx in range(len(self._outputs)):
-            self._outputs[idx].shape.mergeShape([inputs_rank],
-                                                make_symbolic=make_symbolic)
+            self._outputs[idx].mergeShape([inputs_rank],
+                                          make_symbolic=make_symbolic)
             curr_in_shape = self._inputs[idx + 1].value
             if curr_in_shape is None:
                 self.notImplemented('ConcatOffset: Continue resolving?')
@@ -221,8 +221,8 @@ class DynamicStitchOp(Op):
             out_shape = [max_index + 1]
             for rank_id in range(extra_rank):
                 out_shape.append(Dimension(extra_dims[rank_id]))
-            self._outputs[0].shape.mergeShape(out_shape,
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape(out_shape,
+                                        make_symbolic=make_symbolic)
 
         if can_prop_values:
             # Migrate values from data_arrs to output
@@ -272,8 +272,8 @@ class ExpandDimsOp(Op):
             if axis < 0:
                 axis += len(out_shape) + 1
             out_shape.insert(axis, 1)
-            self._outputs[0].shape.mergeShape(out_shape,
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape(out_shape,
+                                        make_symbolic=make_symbolic)
             if self._inputs[0].value is not None:
                 self.notImplemented('ExpandDimsOp propagate vals rank 1+')
 
@@ -311,8 +311,8 @@ class FillOp(Op):
         if out_shape is None:
             print('WARN: FillOp {} shape undetermined'.format(self._name))
             return
-        self._outputs[0].shape.mergeShape(out_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(out_shape,
+                                    make_symbolic=make_symbolic)
         if self._outputs[0].shape.isFullyNumeric():
             if self._outputs[0].shape.isScalar():
                 self._outputs[0].setValue(self._inputs[1].value)
@@ -353,8 +353,8 @@ class GatherOp(Op):
                 out_dims.append(self._inputs[1].shape.getDimension(dim_idx))
             for dim_idx in range(1, self._inputs[0].shape.rank):
                 out_dims.append(self._inputs[0].shape.getDimension(dim_idx))
-            self._outputs[0].shape.mergeShape(out_dims,
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape(out_dims,
+                                        make_symbolic=make_symbolic)
         else:
            self.notImplemented('GatherOp propagateShapes: Non-zero axis')
 
@@ -394,8 +394,8 @@ class InvertPermutationOp(Op):
         if self._inputs[0].shape.isUnknown():
             # Cannot propagate unknown shape
             return
-        self._outputs[0].shape.mergeShape(self._inputs[0].shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(self._inputs[0].shape,
+                                    make_symbolic=make_symbolic)
 
         if self._inputs[0].value is None:
             # Cannot propagate unknown value
@@ -438,16 +438,16 @@ class ListDiffOp(Op):
         in_1_val = np.array(self._inputs[1].value)
         out_val = np.setdiff1d(in_0_val, in_1_val)
         out_shape = [len(out_val)]
-        self._outputs[0].shape.mergeShape(out_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(out_shape,
+                                    make_symbolic=make_symbolic)
         self._outputs[0].setValue(out_val)
         indices = []
         for idx in range(len(in_0_val)):
             if in_0_val[idx] in out_val:
                 indices.append(idx)
         self.debugAssert(len(indices) == len(out_val))
-        self._outputs[1].shape.mergeShape(out_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[1].mergeShape(out_shape,
+                                    make_symbolic=make_symbolic)
         self._outputs[1].setValue(indices)
 
     def calcAlgFlops(self):
@@ -483,8 +483,8 @@ class OneHotOp(Op):
             self.debugAssert(isinstance(self._inputs[1].value,
                                         (int, sympy.Expr)))
             out_shape.append(self._inputs[1].value)
-        self._outputs[0].shape.mergeShape(out_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(out_shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         # One-hot representations have no Flops
@@ -518,8 +518,8 @@ class NumLikeOp(Op):
             if self._inputs[0].shape != self._outputs[0].shape:
                 self.notImplemented('NumLikeOp propagateShapes {}'
                                     .format(self._name))
-            self._outputs[0].shape.mergeShape(self._inputs[0].shape,
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape(self._inputs[0].shape,
+                                        make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         # NumLikeOps have no Flops
@@ -558,7 +558,7 @@ class PadOp(Op):
             new_dim += pad_cfg[idx][0]
             new_dim += pad_cfg[idx][1]
             out_shape.append(new_dim)
-        self._outputs[0].shape.mergeShape(out_shape)
+        self._outputs[0].mergeShape(out_shape)
 
         # TODO: Propagate values if desired
 
@@ -582,7 +582,7 @@ class RankOp(Op):
         self.debugAssert(len(self._inputs) == 1)
         self.debugAssert(len(self._outputs) == 1)
         # Output must be a scalar (no need for make_symbolic, since scalar)
-        self._outputs[0].shape.mergeShape([])
+        self._outputs[0].mergeShape([])
         if not self._inputs[0].shape.isUnknown():
             self._outputs[0].setValue(self._inputs[0].shape.rank)
 
@@ -614,8 +614,8 @@ class ReshapeOp(Op):
 
         num_elts = self._inputs[0].shape.numElements()
         if self._inputs[1].shape.isScalar():
-            self._outputs[0].shape.mergeShape([num_elts],
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape([num_elts],
+                                        make_symbolic=make_symbolic)
         else:
             if self._inputs[1].value is None:
                 if self._inputs[1].shape.isUnknown():
@@ -628,13 +628,13 @@ class ReshapeOp(Op):
                         # Assume that the output must be the flattened
                         # input[0] values, so the shape is the same as the
                         # number of input[0] values.
-                        self._outputs[0].shape.mergeShape([num_elts],
-                                                   make_symbolic=make_symbolic)
+                        self._outputs[0].mergeShape([num_elts],
+                                                    make_symbolic=make_symbolic)
                     elif self._inputs[0].shape.rank == \
                          self._inputs[1].shape.dims[0].value:
                         # Try merging input and output shapes
-                        self._outputs[0].shape.mergeShape(
-                            self._inputs[0].shape, make_symbolic=make_symbolic)
+                        self._outputs[0].mergeShape(self._inputs[0].shape,
+                            make_symbolic=make_symbolic)
                     else:
                         # TODO: Cannot resolve shapes (unknown input[1] value)
                         print('WARN: Reshape {} impl: in1 val {} shape {}'
@@ -671,8 +671,8 @@ class ReshapeOp(Op):
                               .format(self.name, prod_dims, num_elts))
                         return
                     self.debugAssert(prod_dims == num_elts)
-                self._outputs[0].shape.mergeShape(out_shape,
-                                                  make_symbolic=make_symbolic)
+                self._outputs[0].mergeShape(out_shape,
+                                            make_symbolic=make_symbolic)
 
         if self._outputs[0].shape.isFullyNumeric() and \
            self._inputs[0].value is not None:
@@ -705,8 +705,8 @@ class ReverseSequenceOp(Op):
         self.debugAssert(len(self._outputs) == 1)
         # For now, assume reversing sequence dimension does not change
         # the size from input to output tensor.
-        self._outputs[0].shape.mergeShape(self._inputs[0].shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(self._inputs[0].shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         # Reversing a sequence does not require Flops
@@ -745,8 +745,8 @@ class ShapeOp(Op):
             out_dim_0 = self._inputs[idx].shape.rank
             # Currently, rank of a tensor is always defined, so do not allow
             # the output shape to be set to a symbol
-            self._outputs[idx].shape.mergeShape([out_dim_0],
-                                                make_symbolic=False)
+            self._outputs[idx].mergeShape([out_dim_0],
+                                          make_symbolic=False)
 
         # Can set some output values if the input shape is known
         for idx in range(len(self._inputs)):
@@ -810,8 +810,8 @@ class SliceOp(Op):
                 self.debugAssert(end_val <= dim.symbol)
             end_vals.append(end_val)
             out_shape.append(size_val)
-        self._outputs[0].shape.mergeShape(out_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(out_shape,
+                                    make_symbolic=make_symbolic)
 
         # Finally, if possible, propagate values
         if self._inputs[0].value is not None and \
@@ -843,8 +843,7 @@ class SizeOp(Op):
         self.debugAssert(len(self._inputs) == 1)
         self.debugAssert(len(self._outputs) == 1)
         if self._outputs[0].shape.isUnknown():
-            self._outputs[0].shape.mergeShape([],
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape([], make_symbolic=make_symbolic)
         else:
             self.debugAssert(self._outputs[0].shape.isScalar())
         self._outputs[0].setValue(self._inputs[0].shape.numElements())
@@ -903,8 +902,8 @@ class SplitOp(Op):
             out_dims = list(in_tensor.shape.asList())
             for idx, axis_val in enumerate(size_splits.value):
                 out_dims[axis] = axis_val
-                self._outputs[idx].shape.mergeShape(out_dims,
-                                             make_symbolic=make_symbolic)
+                self._outputs[idx].mergeShape(out_dims,
+                                              make_symbolic=make_symbolic)
         else:
             # Case where op should split evenly according to num_splits
             # as indicated by size_splits == 0
@@ -924,8 +923,8 @@ class SplitOp(Op):
                 out_dim._symbol = -(-out_dim._symbol // num_split)
             out_shape.dims[axis] = out_dim
             for out_tensor in self.outputs:
-                out_tensor.shape.mergeShape(out_shape,
-                                            make_symbolic=make_symbolic)
+                out_tensor.mergeShape(out_shape,
+                                      make_symbolic=make_symbolic)
 
         # TODO (Joel): Can split if input is specified
 
@@ -958,8 +957,8 @@ class SqueezeOp(Op):
             for dim in in_shape:
                 if dim.value is None or dim.value > 1:
                     out_shape.append(dim)
-            self._outputs[0].shape.mergeShape(out_shape,
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape(out_shape,
+                                        make_symbolic=make_symbolic)
         else:
             self.notImplemented('Squeeze propagateShapes multi-input')
 
@@ -1073,8 +1072,8 @@ class StridedSliceOp(Op):
                 # If the ranges do not specify these dimensions, then
                 # the input dimension gets preserved to the output
                 out_dims.append(self._inputs[0].shape.getDimension(idx))
-        self._outputs[0].shape.mergeShape(out_dims,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(out_dims,
+                                    make_symbolic=make_symbolic)
 
         # Check if values can be resolved
         if not self._outputs[0].shape.isFullyNumeric() or tensor_vals is None:
@@ -1130,8 +1129,8 @@ class TileOp(Op):
         out_shape = []
         for idx, dim in enumerate(in_shape.dims):
             out_shape.append(dim * multiples_val[idx])
-        self._outputs[0].shape.mergeShape(out_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(out_shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         # TileOps have no Flops
@@ -1164,8 +1163,8 @@ class TransposeOp(Op):
         out_dims = []
         for idx in permutation:
             out_dims.append(in_dims[idx])
-        self._outputs[0].shape.mergeShape(out_dims,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(out_dims,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         # TransposeOps have no Flops
@@ -1188,8 +1187,8 @@ class WhereOp(Op):
         if len(self._inputs) == 1:
             first_dim = utils.getIntSymbolFromString('{}::num_true'
                             .format(self._inputs[0].name))
-            self._outputs[0].shape.mergeShape([first_dim, 1],
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape([first_dim, 1],
+                                        make_symbolic=make_symbolic)
         else:
             self.debugAssert(len(self._inputs) == 3)
             self.notImplemented('Where with 2 inputs')
@@ -1254,8 +1253,8 @@ class PackOp(PackingOp):
         out_shape = list(in_shape.dims)
         num_ins = len(self._inputs)
         out_shape.insert(self._axis, Dimension(num_ins))
-        self._outputs[0].shape.mergeShape(out_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(out_shape,
+                                    make_symbolic=make_symbolic)
 
         # If all input values exist, propagate them
         out_value = []
@@ -1286,8 +1285,8 @@ class UnpackOp(PackingOp):
         out_shape = list(in_shape.dims)
         out_shape.pop(self._axis)
         for out_tensor in self._outputs:
-            out_tensor.shape.mergeShape(out_shape,
-                                        make_symbolic=make_symbolic)
+            out_tensor.mergeShape(out_shape,
+                                  make_symbolic=make_symbolic)
 
         # If values exist in input, propagate them
         if self._inputs[0].value is not None:

--- a/catamount/ops/collective_ops.py
+++ b/catamount/ops/collective_ops.py
@@ -36,8 +36,8 @@ class AllgatherOp(Op):
                 final_shape.append(new_dim)
             else:
                 final_shape.append(dim)
-        self._outputs[0].shape.mergeShape(final_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(final_shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         # Allgathers are only communication and no Flops
@@ -63,8 +63,8 @@ class AllreduceOp(Op):
     def propagateShapes(self, make_symbolic=False):
         self.debugAssert(len(self._inputs) == 1)
         self.debugAssert(len(self._outputs) == 1)
-        self._outputs[0].shape.mergeShape(self._inputs[0].shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(self._inputs[0].shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         # Assume one Flop per data element (this is the minimum)

--- a/catamount/ops/ctrl_ops.py
+++ b/catamount/ops/ctrl_ops.py
@@ -104,8 +104,8 @@ class EnterOp(Op):
             if self._inputs[0].shape != self._outputs[0].shape:
                 self.notImplemented('EnterOp propagateShapes {}'
                                     .format(self._name))
-            self._outputs[0].shape.mergeShape(self._inputs[0].shape,
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape(self._inputs[0].shape,
+                                        make_symbolic=make_symbolic)
         else:
             self.notImplemented(
                 'EnterOp {} propagateShapes unknown input shape'
@@ -145,8 +145,8 @@ class ExitOp(Op):
             if self._inputs[0].shape != self._outputs[0].shape:
                 self.notImplemented('ExitOp propagateShapes {}'
                                     .format(self._name))
-            self._outputs[0].shape.mergeShape(self._inputs[0].shape,
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape(self._inputs[0].shape,
+                                        make_symbolic=make_symbolic)
         else:
             self.notImplemented(
                 'ExitOp {} propagateShapes unknown input shape'
@@ -249,8 +249,8 @@ class MergeOp(Op):
             if in_shape != self._outputs[0].shape:
                 self.notImplemented('MergeOp propagateShapes {}'
                                     .format(self._name))
-            self._outputs[0].shape.mergeShape(in_shape,
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape(in_shape,
+                                        make_symbolic=make_symbolic)
         else:
             self.notImplemented(
                 'MergeOp {} propagateShapes unknown input shape'
@@ -291,8 +291,8 @@ class NextIterationOp(Op):
             if self._inputs[0].shape != self._outputs[0].shape:
                 self.notImplemented('NextIterationOp propagateShapes {}'
                                     .format(self._name))
-            self._outputs[0].shape.mergeShape(self._inputs[0].shape,
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape(self._inputs[0].shape,
+                                        make_symbolic=make_symbolic)
         else:
             self.notImplemented('NextIterationOp {} propagateShapes unknown ' \
                        'input shape'.format(self._name))
@@ -334,15 +334,15 @@ class SwitchOp(Op):
 
         if self._inputs[0].shape != self._outputs[0].shape:
             self.notImplemented('SwitchOp propagateShapes output 0')
-        self._outputs[0].shape.mergeShape(self._inputs[0].shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(self._inputs[0].shape,
+                                    make_symbolic=make_symbolic)
         if self._inputs[0].value is not None:
             self._outputs[0].setValue(self._inputs[0].value)
 
         if self._inputs[0].shape != self._outputs[1].shape:
             self.notImplemented('SwitchOp propagateShapes output 1')
-        self._outputs[1].shape.mergeShape(self._inputs[0].shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[1].mergeShape(self._inputs[0].shape,
+                                    make_symbolic=make_symbolic)
         if self._inputs[0].value is not None:
             self._outputs[1].setValue(self._inputs[0].value)
 

--- a/catamount/ops/init_ops.py
+++ b/catamount/ops/init_ops.py
@@ -12,8 +12,8 @@ class IdentityOp(Op):
         self.debugAssert(self._inputs[0].shape.isUnknown() or
                          self._inputs[0].shape == self._outputs[0].shape)
         if not self._inputs[0].shape.isUnknown():
-            self._outputs[0].shape.mergeShape(self._inputs[0].shape,
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape(self._inputs[0].shape,
+                                        make_symbolic=make_symbolic)
 
         if self._inputs[0].value is not None:
             self._outputs[0].setValue(self._inputs[0].value)
@@ -54,8 +54,8 @@ class RandomInitializerOp(Op):
         self.debugAssert(len(self._inputs) == 1)
         self.debugAssert(len(self._outputs) == 1)
         if self._inputs[0].value is not None:
-            self._outputs[0].shape.mergeShape(self._inputs[0].value,
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape(self._inputs[0].value,
+                                        make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         # Intializers have no Flops

--- a/catamount/ops/loss_ops.py
+++ b/catamount/ops/loss_ops.py
@@ -13,8 +13,8 @@ class InTopKOp(Op):
         target_shape = self._inputs[1].shape
         target_batch = target_shape.getDimension(0)
         self.debugAssert(pred_batch.symbol - target_batch.symbol == 0)
-        self._outputs[0].shape.mergeShape(target_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(target_shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._inputs) == 3)
@@ -45,10 +45,10 @@ class SparseSoftmaxCrossEntropyWithLogitsOp(Op):
         in_0_batch_dim = in_0_shape.getDimension(0)
         in_1_batch_dim = in_1_shape.getDimension(0)
         self.debugAssert(in_0_batch_dim == in_1_batch_dim)
-        self._outputs[0].shape.mergeShape([in_0_batch_dim],
-                                          make_symbolic=make_symbolic)
-        self._outputs[1].shape.mergeShape(in_0_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape([in_0_batch_dim],
+                                    make_symbolic=make_symbolic)
+        self._outputs[1].mergeShape(in_0_shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._inputs) == 2)

--- a/catamount/ops/math_ops.py
+++ b/catamount/ops/math_ops.py
@@ -45,8 +45,8 @@ class BasePointwiseOp(Op):
 
         # Set the output dimensions
         if not final_shape.isUnknown():
-            self._outputs[0].shape.mergeShape(final_shape,
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape(final_shape,
+                                        make_symbolic=make_symbolic)
 
     def flopsPointwise(self):
         self.debugAssert(len(self._outputs) == 1)
@@ -92,8 +92,8 @@ class AddNOp(Op):
                 if not in_tensor.shape.isUnknown():
                     self.debugAssert(in_shape == in_tensor.shape)
         if in_shape is not None:
-            self._outputs[0].shape.mergeShape(in_shape,
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape(in_shape,
+                                        make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._outputs) == 1)
@@ -331,8 +331,8 @@ class SigmoidGradOp(Op):
                 in_shape = self._inputs[1].shape
             else:
                 self.debugAssert(in_shape == self._inputs[1].shape)
-        self._outputs[0].shape.mergeShape(in_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(in_shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._inputs) == 2)
@@ -420,8 +420,8 @@ class TanhGradOp(Op):
                 in_shape = self._inputs[1].shape
             else:
                 self.debugAssert(in_shape == self._inputs[1].shape)
-        self._outputs[0].shape.mergeShape(in_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(in_shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._inputs) == 2)
@@ -505,8 +505,8 @@ class Conv2DGradFilterOp(Conv2DBaseOp):
 
         self.debugAssert(self._inputs[1].value is not None)
         filter_shape = self._inputs[1].value.tolist()
-        self._outputs[0].shape.mergeShape(filter_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(filter_shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._inputs) == 3)
@@ -583,8 +583,8 @@ class Conv2DGradInputOp(Conv2DBaseOp):
         else:
             self.notImplemented('Unknown data format: {}'
                                 .format(self._format))
-        self._outputs[0].shape.mergeShape(out_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(out_shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._inputs) == 3)
@@ -656,8 +656,8 @@ class Conv2DOp(Conv2DBaseOp):
         else:
             self.notImplemented('Unknown data format: {}'
                                 .format(self._format))
-        self._outputs[0].shape.mergeShape(out_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(out_shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._inputs) == 2)
@@ -723,8 +723,8 @@ class MatMulOp(Op):
         if self._transpose_c:
             raise NotImplementedError('Handle transposed output')
         tensor_c = self._outputs[0]
-        tensor_c.shape.mergeShape([first_dim, last_dim],
-                                  make_symbolic=make_symbolic)
+        tensor_c.mergeShape([first_dim, last_dim],
+                            make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         # Get matrix inner dimension
@@ -817,7 +817,7 @@ class BatchMatMulOp(Op):
             out_dims.append(dim_x)
         out_dims.append(first_dim)
         out_dims.append(last_dim)
-        self._outputs[0].shape.mergeShape(out_dims, make_symbolic=True)
+        self._outputs[0].mergeShape(out_dims, make_symbolic=True)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._inputs) == 2)
@@ -922,8 +922,8 @@ class MaxPoolOp(PoolBaseOp):
         else:
             self.notImplemented('Unknown data format: {}'
                                 .format(self._format))
-        self._outputs[0].shape.mergeShape(out_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(out_shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._inputs) == 1)
@@ -950,8 +950,8 @@ class MaxPoolGradOp(PoolBaseOp):
 
         # Simply propagate the input 0 (x) shape to the output, since
         # output is the gradient with respect to x
-        self._outputs[0].shape.mergeShape(self._inputs[0].shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(self._inputs[0].shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._inputs) == 3)
@@ -987,8 +987,8 @@ class RangeOp(Op):
             limit = as_int(limit)
             delta = as_int(delta)
             num_elts = (limit - start + delta - 1) // delta
-            self._outputs[0].shape.mergeShape([num_elts],
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape([num_elts],
+                                        make_symbolic=make_symbolic)
         else:
             self.notImplemented('RangeOp other data type {}'
                                 .format(self._outputs[0].dtype))
@@ -1062,8 +1062,8 @@ class ReduceOp(Op):
                 if dim_index not in axes:
                     dim = self._inputs[0].shape.getDimension(dim_index)
                     out_shape.append(dim)
-            self._outputs[0].shape.mergeShape(out_shape,
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape(out_shape,
+                                        make_symbolic=make_symbolic)
 
             if self._inputs[0].value is not None:
                 if self._reduction_op is not None:
@@ -1105,8 +1105,8 @@ class ScatterUpdateOp(Op):
         self.debugAssert(len(self._inputs) == 3)
         self.debugAssert(len(self._outputs) == 1)
         # Output is same as input[0]
-        self._outputs[0].shape.mergeShape(self._inputs[0].shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(self._inputs[0].shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._inputs) == 3)
@@ -1145,8 +1145,8 @@ class SelectOp(Op):
                 in_shape = self._inputs[2].shape
         # Output is same shape as inputs
         if in_shape is not None:
-            self._outputs[0].shape.mergeShape(in_shape,
-                                              make_symbolic=make_symbolic)
+            self._outputs[0].mergeShape(in_shape,
+                                        make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._inputs) == 3)
@@ -1176,8 +1176,8 @@ class SoftmaxOp(Op):
     def propagateShapes(self, make_symbolic=False):
         self.debugAssert(len(self._inputs) == 1)
         self.debugAssert(len(self._outputs) == 1)
-        self._outputs[0].shape.mergeShape(self._inputs[0].shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(self._inputs[0].shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._inputs) == 1)
@@ -1220,8 +1220,8 @@ class UnsortedSegmentSumOp(Op):
         for dim_idx in range(self._inputs[1].shape.rank,
                              self._inputs[0].shape.rank):
             out_shape.append(self._inputs[0].shape.getDimension(dim_idx))
-        self._outputs[0].shape.mergeShape(out_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(out_shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._inputs) == 3)

--- a/catamount/ops/optimizer_ops.py
+++ b/catamount/ops/optimizer_ops.py
@@ -14,8 +14,8 @@ class ApplyGradientDescentOp(Op):
         self.debugAssert(self._inputs[0].shape == self._inputs[2].shape)
         self.debugAssert(len(self._outputs) == 1)
         out_shape = self._inputs[0].shape
-        self._outputs[0].shape.mergeShape(out_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(out_shape,
+                                    make_symbolic=make_symbolic)
         if self._inputs[0].value is not None and \
            self._inputs[1].value is not None and \
            self._inputs[2].value is not None:
@@ -61,8 +61,8 @@ class ApplyMomentumOp(Op):
         self.debugAssert(self._inputs[0].shape == self._inputs[3].shape)
         self.debugAssert(len(self._outputs) == 1)
         out_shape = self._inputs[0].shape
-        self._outputs[0].shape.mergeShape(out_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(out_shape,
+                                    make_symbolic=make_symbolic)
         if self._inputs[0].value is not None and \
            self._inputs[1].value is not None and \
            self._inputs[2].value is not None and \

--- a/catamount/ops/random_ops.py
+++ b/catamount/ops/random_ops.py
@@ -26,8 +26,8 @@ class MultinomialOp(Op):
         out_shape = []
         out_shape.append(self._inputs[0].shape.getDimension(0))
         out_shape.append(num_samples)
-        self._outputs[0].shape.mergeShape(out_shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(out_shape,
+                                    make_symbolic=make_symbolic)
 
     def calcAlgFlops(self):
         self.debugAssert(len(self._inputs) == 2)
@@ -80,8 +80,8 @@ class CandidateSamplerOp(Op):
         if self._num_true != 1:
             self.notImplemented('CandidateSamplerOp propagateShapes ' \
                                 'num_true != 1')
-        self._outputs[1].shape.mergeShape(self._inputs[0].shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[1].mergeShape(self._inputs[0].shape,
+                                    make_symbolic=make_symbolic)
         num_samples = None
         if self._num_sampled is None:
             samps_name = '{}::rand_samps'.format(self.name)
@@ -89,8 +89,8 @@ class CandidateSamplerOp(Op):
         else:
             self.notImplemented('CandidateSamplerOp: propagateShapes '\
                                 'num_sampled != None')
-        self._outputs[0].shape.mergeShape([num_samples])
-        self._outputs[2].shape.mergeShape([num_samples])
+        self._outputs[0].mergeShape([num_samples])
+        self._outputs[2].mergeShape([num_samples])
 
     def calcAlgFlops(self):
         # TODO: This is a very conservative estimate that there is one Flop to

--- a/catamount/ops/variable.py
+++ b/catamount/ops/variable.py
@@ -72,8 +72,8 @@ class CastOp(Op):
         # Output is same shape as input, propagate if necessary
         self.debugAssert(len(self._inputs) == 1)
         self.debugAssert(len(self._outputs) == 1)
-        self._outputs[0].shape.mergeShape(self._inputs[0].shape,
-                                          make_symbolic=make_symbolic)
+        self._outputs[0].mergeShape(self._inputs[0].shape,
+                                    make_symbolic=make_symbolic)
         if self._inputs[0].value is not None:
             # TODO: Loosen this or clear the values if required
             #       (MAYBE IN setValue?!)

--- a/catamount/tensors/tensor.py
+++ b/catamount/tensors/tensor.py
@@ -188,6 +188,13 @@ class Tensor:
         cons_op = self._consumers.pop(op.name, None)
         assert cons_op is None or cons_op == op
 
+    def mergeShape(self, other, make_symbolic=False):
+        self.shape.mergeShape(other, make_symbolic=make_symbolic)
+        # If the new shape is under-specified, the tensor cannot track
+        # a fully-specified value. In that case, clear the value.
+        if not self.shape.isFullyNumeric() and self._value is not None:
+            self._value = None
+
     def setValue(self, value):
         supported_python_types = ( bool, int, float, sympy.Symbol,
                                    sympy.Expr, str, np.int64, np.int32,

--- a/catamount/tensors/tensor_shape.py
+++ b/catamount/tensors/tensor_shape.py
@@ -9,7 +9,9 @@ def as_dimension(value):
         return value
     elif isinstance(value, (int, np.int64)):
         return Dimension(int(value))
-    elif isinstance(value, (sympy.Symbol, sympy.Expr)):
+    elif isinstance(value, (str, sympy.Symbol, sympy.Expr)):
+        if isinstance(value, str):
+            value = utils.getIntSymbolFromString(value)
         to_return = Dimension(None)
         to_return.setSymbolOrName(value.simplify())
         return to_return

--- a/catamount/tests/cougr_manual_graph.py
+++ b/catamount/tests/cougr_manual_graph.py
@@ -1,6 +1,0 @@
-
-from catamount.tests.utils.catamount_tests import run_manual_graph_test
-
-
-def test_manual_graph():
-    run_manual_graph_test()

--- a/catamount/tests/full/tf_dynamic_rnn_with_backprop.py
+++ b/catamount/tests/full/tf_dynamic_rnn_with_backprop.py
@@ -81,9 +81,9 @@ def test_tf_dynamic_rnn():
     ta_op = graph.opsByName['rnn/TensorArrayStack/TensorArraySizeV3']
     ta_op._outputs[0].setValue(seq_length)
     ta_op = graph.opsByName['rnn/TensorArrayStack/TensorArrayGatherV3']
-    ta_op._outputs[0].shape.mergeShape([seq_length, batch_size, hidden_dim])
+    ta_op._outputs[0].mergeShape([seq_length, batch_size, hidden_dim])
     ta_op = graph.opsByName['rnn/while/TensorArrayReadV3']
-    ta_op._outputs[0].shape.mergeShape([batch_size, hidden_dim])
+    ta_op._outputs[0].mergeShape([batch_size, hidden_dim])
 
     # TODO (Joel): Fix this up when all stack ops work!
     find_stack_shape = TensorShape([None, 24])
@@ -92,9 +92,9 @@ def test_tf_dynamic_rnn():
        op_name_suffix = op.name.split('/')[-1]
        if 'StackPopV2' in op_name_suffix:
            if op._outputs[0].shape == find_stack_shape:
-               op._outputs[0].shape.mergeShape([batch_size, hidden_dim])
+               op._outputs[0].mergeShape([batch_size, hidden_dim])
            elif op._outputs[0].shape == find_stack_shape_2:
-               op._outputs[0].shape.mergeShape([batch_size, 2 * hidden_dim])
+               op._outputs[0].mergeShape([batch_size, 2 * hidden_dim])
 
     # NOTE: This also works: batch_size = 'batch_size'
     # Bind placeholders (a and b) output dimensions 0 to name batch_size

--- a/catamount/tests/full/tf_language_models.py
+++ b/catamount/tests/full/tf_language_models.py
@@ -185,7 +185,7 @@ def run_tf_language_model(domain=None, build_projection=False):
                                          base_subbatch_size,
                                          base_hidden_dim]
                             # Verify that the shape is clearly specified
-                            op._outputs[0].shape.mergeShape(out_shape, make_symbolic=True)
+                            op._outputs[0].mergeShape(out_shape, make_symbolic=True)
                             gather_shape = [sequence_length_symbol,
                                             subbatch_size_symbol,
                                             hidden_dim_symbol]
@@ -193,7 +193,7 @@ def run_tf_language_model(domain=None, build_projection=False):
                             # This TAGather is known to be unused, so who cares?!
                             assert len(op._outputs[0].consumers) == 0
                             continue
-                op._outputs[0].shape.mergeShape(gather_shape, make_symbolic=True)
+                op._outputs[0].mergeShape(gather_shape, make_symbolic=True)
             elif 'TensorArraySize' in op_name_suffix:
                 assert isinstance(op, UnknownOp)
                 assert len(op._inputs) == 2
@@ -210,7 +210,7 @@ def run_tf_language_model(domain=None, build_projection=False):
                 if not op._outputs[0].shape.isUnknown():
                     assert op._outputs[0].shape.dims[1].value == base_hidden_dim
                 read_shape = [subbatch_size_symbol, hidden_dim_symbol]
-                op._outputs[0].shape.mergeShape(read_shape, make_symbolic=True)
+                op._outputs[0].mergeShape(read_shape, make_symbolic=True)
     else:
         raise NotImplementedError('ERROR: Unknown domain: {}'.format(domain))
 
@@ -323,11 +323,11 @@ def run_tf_language_model(domain=None, build_projection=False):
     elif domain == 'nmt':
         # HAX: Manually hack the iterator op
         it_op = graph.opsByName['IteratorGetNext']
-        it_op._outputs[0].shape.mergeShape([subbatch_size_symbol, sequence_length_symbol], make_symbolic=True)
-        it_op._outputs[1].shape.mergeShape([subbatch_size_symbol, sequence_length_symbol], make_symbolic=True)
-        it_op._outputs[2].shape.mergeShape([subbatch_size_symbol, sequence_length_symbol], make_symbolic=True)
-        it_op._outputs[3].shape.mergeShape([subbatch_size_symbol], make_symbolic=True)
-        it_op._outputs[4].shape.mergeShape([subbatch_size_symbol], make_symbolic=True)
+        it_op._outputs[0].mergeShape([subbatch_size_symbol, sequence_length_symbol], make_symbolic=True)
+        it_op._outputs[1].mergeShape([subbatch_size_symbol, sequence_length_symbol], make_symbolic=True)
+        it_op._outputs[2].mergeShape([subbatch_size_symbol, sequence_length_symbol], make_symbolic=True)
+        it_op._outputs[3].mergeShape([subbatch_size_symbol], make_symbolic=True)
+        it_op._outputs[4].mergeShape([subbatch_size_symbol], make_symbolic=True)
 
         bind_dict = { # Constants
                       'gradients/dynamic_seq2seq/decoder/decoder/while/BasicDecoderStep/decoder/attention/attention_layer/MatMul/Enter_grad/b_acc': [3 * hidden_dim_symbol, hidden_dim_symbol],
@@ -373,7 +373,7 @@ def run_tf_language_model(domain=None, build_projection=False):
             push_op = graph._ops_by_name[push_name]
             # Verify StackPush input[1].shape == StackPop output[0].shape
             assert push_op._inputs[1].shape == op._outputs[0].shape
-            op._outputs[0].shape.mergeShape(push_op._inputs[1].shape, make_symbolic=True)
+            op._outputs[0].mergeShape(push_op._inputs[1].shape, make_symbolic=True)
             if push_op._inputs[1].value is not None:
                 op._outputs[0].setValue(push_op._inputs[1].value)
 

--- a/catamount/tests/full/tf_language_models.py
+++ b/catamount/tests/full/tf_language_models.py
@@ -1,6 +1,7 @@
 import argparse
 import numpy as np
 import pickle
+import re
 import sympy
 import sys
 sys.setrecursionlimit(50000)
@@ -193,8 +194,6 @@ def run_tf_language_model(domain=None, build_projection=False):
                             assert len(op._outputs[0].consumers) == 0
                             continue
                 op._outputs[0].shape.mergeShape(gather_shape, make_symbolic=True)
-                for idx in range(op._outputs[0].shape.rank):
-                    op._outputs[0].shape.dims[idx]._value = None
             elif 'TensorArraySize' in op_name_suffix:
                 assert isinstance(op, UnknownOp)
                 assert len(op._inputs) == 2
@@ -212,8 +211,6 @@ def run_tf_language_model(domain=None, build_projection=False):
                     assert op._outputs[0].shape.dims[1].value == base_hidden_dim
                 read_shape = [subbatch_size_symbol, hidden_dim_symbol]
                 op._outputs[0].shape.mergeShape(read_shape, make_symbolic=True)
-                for idx in range(op._outputs[0].shape.rank):
-                    op._outputs[0].shape.dims[idx]._value = None
     else:
         raise NotImplementedError('ERROR: Unknown domain: {}'.format(domain))
 
@@ -221,114 +218,12 @@ def run_tf_language_model(domain=None, build_projection=False):
 
     if domain == 'wordlm':
         const_dict = {
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_lstm_1/rnn/while/rnn/BiasAdd/Enter_grad/b_acc': [4 * hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_lstm_1/rnn/while/rnn/MatMul/Enter_grad/b_acc': [2 * hidden_dim_symbol, 4 * hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_2_lstm_1/rnn/while/rnn/BiasAdd/Enter_grad/b_acc': [4 * hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_2_lstm_1/rnn/while/rnn/MatMul/Enter_grad/b_acc': [2 * hidden_dim_symbol, 4 * hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_lstm_1/rnn/while/rnn/BiasAdd/Enter_grad/b_acc': [4 * hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_lstm_1/rnn/while/rnn/MatMul/Enter_grad/b_acc': [2 * hidden_dim_symbol, 4 * hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_2_lstm_1/rnn/while/rnn/BiasAdd/Enter_grad/b_acc': [4 * hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_2_lstm_1/rnn/while/rnn/MatMul/Enter_grad/b_acc': [2 * hidden_dim_symbol, 4 * hidden_dim_symbol],
-                    }
-    elif domain == 'charlm':
-        const_dict = {
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_0/h_0/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_0/h_0/MatMul/Enter_grad/b_acc': [2 * hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_1/h_1/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_1/h_1/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_2/h_2/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_2/h_2/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_3/h_3/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_3/h_3/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_4/h_4/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_4/h_4/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_5/h_5/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_5/h_5/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_6/h_6/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_6/h_6/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_7/h_7/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_7/h_7/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_8/h_8/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_8/h_8/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_9/h_9/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/h_9/h_9/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_0/t_0/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_0/t_0/MatMul/Enter_grad/b_acc': [2 * hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_1/t_1/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_1/t_1/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_2/t_2/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_2/t_2/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_3/t_3/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_3/t_3/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_4/t_4/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_4/t_4/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_5/t_5/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_5/t_5/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_6/t_6/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_6/t_6/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_7/t_7/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_7/t_7/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_8/t_8/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_8/t_8/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_9/t_9/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
-                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/t_9/t_9/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_0/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_1/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_2/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_3/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_4/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_5/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_6/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_7/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_8/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_9/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_0/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_1/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_2/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_3/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_4/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_5/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_6/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_7/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_8/Bias/Initializer/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_9/Bias/Initializer/Const': [hidden_dim_symbol],
-                    }
-    elif domain == 'nmt':
-        const_dict = {
-                      'gradients/dynamic_seq2seq/decoder/decoder/while/BasicDecoderStep/decoder/attention/attention_layer/MatMul/Enter_grad/b_acc': [3 * hidden_dim_symbol, hidden_dim_symbol],
-                      'gradients/dynamic_seq2seq/decoder/decoder/while/BasicDecoderStep/decoder/attention/basic_lstm_cell/BiasAdd/Enter_grad/b_acc': [4 * hidden_dim_symbol],
-                      'gradients/dynamic_seq2seq/decoder/decoder/while/BasicDecoderStep/decoder/attention/basic_lstm_cell/MatMul/Enter_grad/b_acc': [3 * hidden_dim_symbol, 4 * hidden_dim_symbol],
-                      'gradients/dynamic_seq2seq/encoder/bidirectional_rnn/bw/bw/while/basic_lstm_cell/BiasAdd/Enter_grad/b_acc': [4 * hidden_dim_symbol],
-                      'gradients/dynamic_seq2seq/encoder/bidirectional_rnn/bw/bw/while/basic_lstm_cell/MatMul/Enter_grad/b_acc': [2 * hidden_dim_symbol, 4 * hidden_dim_symbol],
-                      'gradients/dynamic_seq2seq/encoder/bidirectional_rnn/fw/fw/while/basic_lstm_cell/BiasAdd/Enter_grad/b_acc': [4 * hidden_dim_symbol],
-                      'gradients/dynamic_seq2seq/encoder/bidirectional_rnn/fw/fw/while/basic_lstm_cell/MatMul/Enter_grad/b_acc': [2 * hidden_dim_symbol, 4 * hidden_dim_symbol],
-                    }
-    else:
-        raise NotImplementedError('Manually set constant op shapes for domain {}'.format(domain))
-
-    for const_key, const_shape in const_dict.items():
-        try:
-            if const_key in graph.opsByName.keys():
-                const_op = graph.opsByName[const_key]
-                assert isinstance(const_op, ConstantOp)
-                const_op._outputs[0].shape.mergeShape(const_shape, make_symbolic=True)
-                if const_op._outputs[0].value is not None:
-                    const_op._outputs[0]._value = None
-            else:
-                print('WARN: ConstantOp not found: {}'.format(const_key))
-        except Exception as exc:
-            print('WARN: ConstantOp unknown problem: {}: {}'.format(const_key, exc))
-
-    if domain == 'wordlm':
-        const_dict = {
                       'Model/Collapse/Reshape/shape': [-1, hidden_dim_symbol],
-                      'Model/Recurrent_1_lstm_1/rnn/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_1_lstm_1/rnn/Const_1': [hidden_dim_symbol],
-                      'Model/Recurrent_2_lstm_1/rnn/Const': [hidden_dim_symbol],
-                      'Model/Recurrent_2_lstm_1/rnn/Const_1': [hidden_dim_symbol],
+                      'Model/Recurrent_\d_lstm_1/rnn/Const': [hidden_dim_symbol],
+                      'Model/Recurrent_\d_lstm_1/rnn/Const_1': [hidden_dim_symbol],
                       'Model/Gradient/Compute/gradients/Model/Embedding_1_1/Gather_grad/Shape': [vocab_size_symbol, hidden_dim_symbol],
                       'Model/Gradient/Compute/gradients/Model/FullSoftmaxLoss_1_1/add_grad/Shape_1': [1, vocab_size_symbol],
-                    }
+                     }
     elif domain == 'charlm':
         const_dict = {
                       'Model/Collapse/Reshape/shape': [-1, hidden_dim_symbol],
@@ -343,18 +238,10 @@ def run_tf_language_model(domain=None, build_projection=False):
                        'gradients/dynamic_seq2seq/decoder/embedding_lookup_grad/Shape': [vocab_size_symbol, hidden_dim_symbol],
                        'gradients/dynamic_seq2seq/encoder/embedding_lookup_grad/Shape': [vocab_size_symbol, hidden_dim_symbol],
                        'gradients/dynamic_seq2seq/decoder/LuongAttention/memory_layer/Tensordot/Reshape_1_grad/Shape': [2 * hidden_dim_symbol, hidden_dim_symbol],
-                       'dynamic_seq2seq/encoder/bidirectional_rnn/fw/fw/Const_1': [hidden_dim_symbol],
-                       'dynamic_seq2seq/encoder/bidirectional_rnn/fw/fw/Const_4': [hidden_dim_symbol],
-                       'dynamic_seq2seq/encoder/bidirectional_rnn/fw/fw/DeviceWrapperZeroState/DropoutWrapperZeroState/BasicLSTMCellZeroState/Const': [hidden_dim_symbol],
-                       'dynamic_seq2seq/encoder/bidirectional_rnn/fw/fw/DeviceWrapperZeroState/DropoutWrapperZeroState/BasicLSTMCellZeroState/Const_1': [hidden_dim_symbol],
-                       'dynamic_seq2seq/encoder/bidirectional_rnn/fw/fw/DeviceWrapperZeroState/DropoutWrapperZeroState/BasicLSTMCellZeroState/Const_2': [hidden_dim_symbol],
-                       'dynamic_seq2seq/encoder/bidirectional_rnn/fw/fw/DeviceWrapperZeroState/DropoutWrapperZeroState/BasicLSTMCellZeroState/Const_3': [hidden_dim_symbol],
-                       'dynamic_seq2seq/encoder/bidirectional_rnn/bw/bw/Const_1': [hidden_dim_symbol],
-                       'dynamic_seq2seq/encoder/bidirectional_rnn/bw/bw/Const_4': [hidden_dim_symbol],
-                       'dynamic_seq2seq/encoder/bidirectional_rnn/bw/bw/DeviceWrapperZeroState/DropoutWrapperZeroState/BasicLSTMCellZeroState/Const': [hidden_dim_symbol],
-                       'dynamic_seq2seq/encoder/bidirectional_rnn/bw/bw/DeviceWrapperZeroState/DropoutWrapperZeroState/BasicLSTMCellZeroState/Const_1': [hidden_dim_symbol],
-                       'dynamic_seq2seq/encoder/bidirectional_rnn/bw/bw/DeviceWrapperZeroState/DropoutWrapperZeroState/BasicLSTMCellZeroState/Const_2': [hidden_dim_symbol],
-                       'dynamic_seq2seq/encoder/bidirectional_rnn/bw/bw/DeviceWrapperZeroState/DropoutWrapperZeroState/BasicLSTMCellZeroState/Const_3': [hidden_dim_symbol],
+                       'dynamic_seq2seq/encoder/bidirectional_rnn/[bf]w/[bf]w/Const_1': [hidden_dim_symbol],
+                       'dynamic_seq2seq/encoder/bidirectional_rnn/[bf]w/[bf]w/Const_4': [hidden_dim_symbol],
+                       'dynamic_seq2seq/encoder/bidirectional_rnn/[bf]w/[bf]w/DeviceWrapperZeroState/DropoutWrapperZeroState/BasicLSTMCellZeroState/Const': [hidden_dim_symbol],
+                       'dynamic_seq2seq/encoder/bidirectional_rnn/[bf]w/[bf]w/DeviceWrapperZeroState/DropoutWrapperZeroState/BasicLSTMCellZeroState/Const_\d': [hidden_dim_symbol],
                        'dynamic_seq2seq/decoder/output_projection/Tensordot/Reshape_1/shape': [hidden_dim_symbol, vocab_size_symbol],
                        'dynamic_seq2seq/decoder/output_projection/Tensordot/Const_2': [vocab_size_symbol],
                        'dynamic_seq2seq/decoder/decoder/Const': [hidden_dim_symbol],
@@ -364,59 +251,58 @@ def run_tf_language_model(domain=None, build_projection=False):
                        'dynamic_seq2seq/decoder/DeviceWrapperZeroState/AttentionWrapperZeroState/Const': [hidden_dim_symbol],
                        'dynamic_seq2seq/decoder/DeviceWrapperZeroState/AttentionWrapperZeroState/Const_1': [hidden_dim_symbol],
                        'dynamic_seq2seq/decoder/DeviceWrapperZeroState/AttentionWrapperZeroState/DeviceWrapperZeroState/DropoutWrapperZeroState/BasicLSTMCellZeroState/Const': [hidden_dim_symbol],
-                       'dynamic_seq2seq/decoder/DeviceWrapperZeroState/AttentionWrapperZeroState/DeviceWrapperZeroState/DropoutWrapperZeroState/BasicLSTMCellZeroState/Const_1': [hidden_dim_symbol],
-                       'dynamic_seq2seq/decoder/DeviceWrapperZeroState/AttentionWrapperZeroState/DeviceWrapperZeroState/DropoutWrapperZeroState/BasicLSTMCellZeroState/Const_2': [hidden_dim_symbol],
-                       'dynamic_seq2seq/decoder/DeviceWrapperZeroState/AttentionWrapperZeroState/DeviceWrapperZeroState/DropoutWrapperZeroState/BasicLSTMCellZeroState/Const_3': [hidden_dim_symbol],
+                       'dynamic_seq2seq/decoder/DeviceWrapperZeroState/AttentionWrapperZeroState/DeviceWrapperZeroState/DropoutWrapperZeroState/BasicLSTMCellZeroState/Const_\d': [hidden_dim_symbol],
                        'buffer_size': 256 * hidden_dim_symbol,
                        'buffer_size_1': 256 * hidden_dim_symbol,
-                       'buffer_size_2': 125 * hidden_dim_symbol,
-                       'buffer_size_3': 125 * hidden_dim_symbol,
-                       'buffer_size_4': 125 * hidden_dim_symbol,
-                       'buffer_size_5': 125 * hidden_dim_symbol,
-                       'buffer_size_6': 125 * hidden_dim_symbol,
-                       'buffer_size_7': 125 * hidden_dim_symbol,
-                       'buffer_size_8': 125 * hidden_dim_symbol,
-
+                       'buffer_size_[2-8]': 125 * hidden_dim_symbol,
                      }
     else:
         raise NotImplementedError('Manually set constant op values for domain {}'.format(domain))
 
     for const_key, const_val in const_dict.items():
         try:
-            if const_key in graph.opsByName.keys():
-                const_op = graph.opsByName[const_key]
-                assert isinstance(const_op, ConstantOp)
-                const_op._outputs[0].setValue(const_val)
-            else:
-                print('WARN: ConstantOp not found: {}'.format(const_key))
+            const_key_str = '^{}$'.format(const_key)
+            key_found = False
+            for op_key in graph.opsByName.keys():
+                if re.match(const_key_str, op_key):
+                    const_op = graph.opsByName[op_key]
+                    assert isinstance(const_op, ConstantOp), \
+                           'Matched non-const op!: {}' \
+                           .format(const_op.debugString())
+                    const_op._outputs[0].setValue(const_val)
+                    key_found = True
+            if not key_found:
+                print('WARN: ConstantOp not found: {}'.format(const_key_str))
         except Exception as exc:
-            print('WARN: ConstantOp unknown problem: {}: {}'.format(const_key, exc))
+            print('WARN: ConstantOp unknown problem: {}: {}'
+                  .format(const_key_str, exc))
 
 
-    # Next, bind the placeholders and propagate shapes
+    # Next, bind the constant, placeholder, and variable shapes and propagate
     if domain == 'wordlm':
-        bind_dict = { # Placeholders
+        bind_dict = { # Constants
+                      'Model/Gradient/Compute/gradients/Model/Recurrent_\d_lstm_1/rnn/while/rnn/BiasAdd/Enter_grad/b_acc': [4 * hidden_dim_symbol],
+                      'Model/Gradient/Compute/gradients/Model/Recurrent_\d_lstm_1/rnn/while/rnn/MatMul/Enter_grad/b_acc': [2 * hidden_dim_symbol, 4 * hidden_dim_symbol],
+                      # Placeholders
                       'Input/Input': [subbatch_size_symbol, sequence_length_symbol],
                       'Labels/Labels': [subbatch_size_symbol, sequence_length_symbol],
                       'Model/Placeholder': [subbatch_size_symbol, hidden_dim_symbol],
-                      'Model/Placeholder_1': [subbatch_size_symbol, hidden_dim_symbol],
-                      'Model/Placeholder_2': [subbatch_size_symbol, hidden_dim_symbol],
-                      'Model/Placeholder_3': [subbatch_size_symbol, hidden_dim_symbol],
-                      'Model/Placeholder_4': [subbatch_size_symbol, hidden_dim_symbol],
-                      'Model/Placeholder_5': [subbatch_size_symbol, hidden_dim_symbol],
-                      'Model/Placeholder_6': [subbatch_size_symbol, hidden_dim_symbol],
-                      'Model/Placeholder_7': [subbatch_size_symbol, hidden_dim_symbol],
+                      'Model/Placeholder_\d': [subbatch_size_symbol, hidden_dim_symbol],
                       # Variables
                       'Model/Embedding_1/EmbeddingWeights': [vocab_size_symbol, hidden_dim_symbol],
                       'Model/FullSoftmaxLoss_1/W_Softmax': [vocab_size_symbol, hidden_dim_symbol],
                       'Model/FullSoftmaxLoss_1/b_Softmax': [1, vocab_size_symbol],
-                      'Model/Recurrent_1_lstm/rnn/Bias': [4 * hidden_dim_symbol],
-                      'Model/Recurrent_1_lstm/rnn/Matrix': [2 * hidden_dim_symbol, 4 * hidden_dim_symbol],
-                      'Model/Recurrent_2_lstm/rnn/Bias': [4 * hidden_dim_symbol],
-                      'Model/Recurrent_2_lstm/rnn/Matrix': [2 * hidden_dim_symbol, 4 * hidden_dim_symbol],
+                      'Model/Recurrent_\d_lstm/rnn/Bias': [4 * hidden_dim_symbol],
+                      'Model/Recurrent_\d_lstm/rnn/Matrix': [2 * hidden_dim_symbol, 4 * hidden_dim_symbol],
                     }
     elif domain == 'charlm':
-        bind_dict = { # Placeholders
+        bind_dict = { # Constants
+                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/[ht]_0/[ht]_0/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
+                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/[ht]_0/[ht]_0/MatMul/Enter_grad/b_acc': [2 * hidden_dim_symbol, hidden_dim_symbol],
+                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/[ht]_[1-9]/[ht]_[1-9]/BiasAdd/Enter_grad/b_acc': [hidden_dim_symbol],
+                      'Model/Gradient/Compute/gradients/Model/Recurrent_1_rhn_1/rnn/while/[ht]_[1-9]/[ht]_[1-9]/MatMul/Enter_grad/b_acc': [hidden_dim_symbol, hidden_dim_symbol],
+                      'Model/Recurrent_1_rhn/rnn/[ht]_[0-9]/Bias/Initializer/Const': [hidden_dim_symbol],
+                      # Placeholders
                       'Input/Input': [subbatch_size_symbol, sequence_length_symbol],
                       'Labels/Labels': [subbatch_size_symbol, sequence_length_symbol],
                       'Model/Placeholder': [subbatch_size_symbol, hidden_dim_symbol],
@@ -427,44 +313,12 @@ def run_tf_language_model(domain=None, build_projection=False):
                       'Model/FullSoftmaxLoss_1/b_Softmax': [1, vocab_size_symbol],
                       'Model/Recurrent_1_rhn/rnn/h_0/Bias': [hidden_dim_symbol],
                       'Model/Recurrent_1_rhn/rnn/h_0/Matrix': [2 * hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_1/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_1/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_2/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_2/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_3/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_3/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_4/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_4/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_5/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_5/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_6/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_6/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_7/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_7/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_8/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_8/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_9/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/h_9/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
+                      'Model/Recurrent_1_rhn/rnn/h_[1-9]/Bias': [hidden_dim_symbol],
+                      'Model/Recurrent_1_rhn/rnn/h_[1-9]/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
                       'Model/Recurrent_1_rhn/rnn/t_0/Bias': [hidden_dim_symbol],
                       'Model/Recurrent_1_rhn/rnn/t_0/Matrix': [2 * hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_1/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_1/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_2/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_2/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_3/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_3/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_4/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_4/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_5/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_5/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_6/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_6/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_7/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_7/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_8/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_8/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_9/Bias': [hidden_dim_symbol],
-                      'Model/Recurrent_1_rhn/rnn/t_9/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
+                      'Model/Recurrent_1_rhn/rnn/t_[1-9]/Bias': [hidden_dim_symbol],
+                      'Model/Recurrent_1_rhn/rnn/t_[1-9]/Matrix': [hidden_dim_symbol, hidden_dim_symbol],
                     }
     elif domain == 'nmt':
         # HAX: Manually hack the iterator op
@@ -475,17 +329,21 @@ def run_tf_language_model(domain=None, build_projection=False):
         it_op._outputs[3].shape.mergeShape([subbatch_size_symbol], make_symbolic=True)
         it_op._outputs[4].shape.mergeShape([subbatch_size_symbol], make_symbolic=True)
 
-        bind_dict = { # Placeholders
+        bind_dict = { # Constants
+                      'gradients/dynamic_seq2seq/decoder/decoder/while/BasicDecoderStep/decoder/attention/attention_layer/MatMul/Enter_grad/b_acc': [3 * hidden_dim_symbol, hidden_dim_symbol],
+                      'gradients/dynamic_seq2seq/decoder/decoder/while/BasicDecoderStep/decoder/attention/basic_lstm_cell/BiasAdd/Enter_grad/b_acc': [4 * hidden_dim_symbol],
+                      'gradients/dynamic_seq2seq/decoder/decoder/while/BasicDecoderStep/decoder/attention/basic_lstm_cell/MatMul/Enter_grad/b_acc': [3 * hidden_dim_symbol, 4 * hidden_dim_symbol],
+                      'gradients/dynamic_seq2seq/encoder/bidirectional_rnn/[bf]w/[bf]w/while/basic_lstm_cell/BiasAdd/Enter_grad/b_acc': [4 * hidden_dim_symbol],
+                      'gradients/dynamic_seq2seq/encoder/bidirectional_rnn/[bf]w/[bf]w/while/basic_lstm_cell/MatMul/Enter_grad/b_acc': [2 * hidden_dim_symbol, 4 * hidden_dim_symbol],
+                      # Placeholders
                       # Variables
                       'dynamic_seq2seq/decoder/attention/attention_layer/kernel': [3 * hidden_dim_symbol, hidden_dim_symbol],
                       'dynamic_seq2seq/decoder/attention/basic_lstm_cell/bias': [4 * hidden_dim_symbol],
                       'dynamic_seq2seq/decoder/attention/basic_lstm_cell/kernel': [3 * hidden_dim_symbol, 4 * hidden_dim_symbol],
                       'dynamic_seq2seq/decoder/memory_layer/kernel': [2 * hidden_dim_symbol, hidden_dim_symbol],
                       'dynamic_seq2seq/decoder/output_projection/kernel': [hidden_dim_symbol, vocab_size_symbol],
-                      'dynamic_seq2seq/encoder/bidirectional_rnn/bw/basic_lstm_cell/bias': [4 * hidden_dim_symbol],
-                      'dynamic_seq2seq/encoder/bidirectional_rnn/bw/basic_lstm_cell/kernel': [2 * hidden_dim_symbol, 4 * hidden_dim_symbol],
-                      'dynamic_seq2seq/encoder/bidirectional_rnn/fw/basic_lstm_cell/bias': [4 * hidden_dim_symbol],
-                      'dynamic_seq2seq/encoder/bidirectional_rnn/fw/basic_lstm_cell/kernel': [2 * hidden_dim_symbol, 4 * hidden_dim_symbol],
+                      'dynamic_seq2seq/encoder/bidirectional_rnn/[bf]w/basic_lstm_cell/bias': [4 * hidden_dim_symbol],
+                      'dynamic_seq2seq/encoder/bidirectional_rnn/[bf]w/basic_lstm_cell/kernel': [2 * hidden_dim_symbol, 4 * hidden_dim_symbol],
                       'embeddings/decoder/embedding_decoder': [vocab_size_symbol, hidden_dim_symbol],
                       'embeddings/encoder/embedding_encoder': [vocab_size_symbol, hidden_dim_symbol],
                     }
@@ -929,7 +787,7 @@ if __name__ == "__main__":
     parser.add_argument('--domain', choices=domain_choices, required=True,
                         help='The domain to test ({})'.format(domain_choices))
     parser.add_argument('--build_projection', action="store_true",
-                    help='Add a projection layer to the model')
+                        help='Add a projection layer to the model')
     args = parser.parse_args()
 
     run_tf_language_model(domain=args.domain,


### PR DESCRIPTION
In prep for some future changes, refine the way that the Graph can bind
tensor shapes. We need to bind shapes for all constants, placeholders, and
variables in the graph (source ops into the computations). Allow binding
constants, and use regular expressions to match all ops that have the same
naming conventions and op shapes.