### PR TITLE
ContextFrames: Add a concept of a context for compute blocks

### DIFF
--- a/catamount/frameworks/tensorflow.py
+++ b/catamount/frameworks/tensorflow.py
@@ -414,6 +414,9 @@ def get_batch_matmul_attributes_from_op(tf_sess, tf_op, op):
     op.setAdjointX(tf_op.get_attr('adj_x'))
     op.setAdjointY(tf_op.get_attr('adj_y'))
 
+def get_enter_frame_name_from_op(tf_sess, tf_op, op):
+    op.setFrameName(tf_op.get_attr('frame_name').decode('utf-8'))
+
 def parse_tf_op_attributes_into_op(tf_sess, tf_op, op):
     # tf_op.op_def is the parameterization for protobuf
     # tf_op.node_def contains the arguments from protobuf to apply to op
@@ -450,6 +453,9 @@ def parse_tf_op_attributes_into_op(tf_sess, tf_op, op):
     elif isinstance(op, BatchMatMulOp):
         get_batch_matmul_attributes_from_op(tf_sess, tf_op, op)
 
+    elif isinstance(op, EnterOp):
+        get_enter_frame_name_from_op(tf_sess, tf_op, op)
+
     # print(tf_op.op_def)
     # print(tf_op.node_def)
 
@@ -457,6 +463,7 @@ def construct_catamount_graph(tf_sess, tf_graph):
     graph = Graph()
     tensors = {}
     op_inputs = {}
+    ctrl_frames = {}
     for tf_op in tf_graph._nodes_by_name.values():
         if tf_op.type in TF_OP_TO_CATAMOUNT.keys():
             # Map to Catamount op type
@@ -520,6 +527,12 @@ def construct_catamount_graph(tf_sess, tf_graph):
 
         # Get the tf_op's attributes and set them as necessary
         parse_tf_op_attributes_into_op(tf_sess, tf_op, op)
+
+        if catamount_type == EnterOp:
+            frame_name = op.getFrameName()
+            if frame_name not in ctrl_frames:
+                ctrl_frames[frame_name] = ContextFrame(frame_name)
+            ctrl_frames[frame_name].addEnterOp(op)
 
         graph.addOp(op)
 

--- a/catamount/frameworks/tensorflow.py
+++ b/catamount/frameworks/tensorflow.py
@@ -630,6 +630,7 @@ def construct_catamount_graph(tf_sess, tf_graph):
     for op_name, op in graph.opsByName.items():
         if op.isControlOp():
             control_ops.append(op)
+    assert len(control_ops) == len(ctrl_frames)
     for ctrl_op in control_ops:
         # Get all ops for the loop condition value calculation (1 and 2),
         # the variable contexts (3), and the loop body (4). Extract these
@@ -654,11 +655,21 @@ def construct_catamount_graph(tf_sess, tf_graph):
             assert not next_op.isControlOp(), \
                 'Catamount Framework(TF): Should be no up-stream control blocks!'
             visited_ops.add(next_op)
-            if isinstance(next_op, EnterOp) or \
-               isinstance(next_op, NextIterationOp):
-                # Do not traverse past EnterOps, NextIterationOps
+            if isinstance(next_op, EnterOp):
+                # Add EnterOps to the frontier and visited by looking up all
+                # the EnterOps associated with their context frame. Will
+                # traverse forward from them to ExitOps or MergeOps
+                ctx_frame = next_op._context_frame
+                for enter_op in ctx_frame._enter_ops.values():
+                    if enter_op not in frontier_ops:
+                        frontier_ops.append(enter_op)
+                        visited_ops.add(enter_op)
+                # Do not traverse past EnterOps
                 continue
-            if isinstance(next_op, MergeOp):
+            elif isinstance(next_op, NextIterationOp):
+                # Do not traverse past NextIterationOps
+                continue
+            elif isinstance(next_op, MergeOp):
                 frontier_ops.append(next_op)
             for in_tensor in next_op.inputs:
                 bwd_frontier_ops.append(in_tensor.producer)

--- a/catamount/ops/ctrl_ops.py
+++ b/catamount/ops/ctrl_ops.py
@@ -8,6 +8,10 @@ class ContextFrame:
         self._name = name
         self._enter_ops = {}
 
+    @property
+    def name(self):
+        return self._name
+
     def __str__(self):
         to_return = 'ContextFrame(name: {}):'.format(self._name)
         for enter_op in self._enter_ops.values():
@@ -16,6 +20,7 @@ class ContextFrame:
 
     def addEnterOp(self, enter_op):
         self._enter_ops[enter_op.name] = enter_op
+        enter_op.setContextFrame(self)
 
 
 class ControlBlockOp(SubgraphOp):
@@ -111,6 +116,7 @@ class EnterOp(Op):
     def __init__(self, name):
         super(EnterOp, self).__init__(name)
         self._frame_name = None
+        self._context_frame = None
 
     def setFrameName(self, frame_name):
         self.debugAssert(self._frame_name is None)
@@ -118,6 +124,9 @@ class EnterOp(Op):
 
     def getFrameName(self):
         return self._frame_name
+
+    def setContextFrame(self, context_frame):
+        self._context_frame = context_frame
 
     def propagateShapes(self, make_symbolic=False):
         # EnterOps should forward their inputs to their outputs

--- a/catamount/ops/ctrl_ops.py
+++ b/catamount/ops/ctrl_ops.py
@@ -3,6 +3,21 @@ from .subgraph_op import SubgraphOp
 from ..api import utils
 
 
+class ContextFrame:
+    def __init__(self, name):
+        self._name = name
+        self._enter_ops = {}
+
+    def __str__(self):
+        to_return = 'ContextFrame(name: {}):'.format(self._name)
+        for enter_op in self._enter_ops.values():
+            to_return += '\n  Enter: {}'.format(enter_op.name)
+        return to_return
+
+    def addEnterOp(self, enter_op):
+        self._enter_ops[enter_op.name] = enter_op
+
+
 class ControlBlockOp(SubgraphOp):
     ''' A ControlBlockOp designates a subgraph that manages some form of
         dynamic control flow for a compute graph (e.g., if-conditionals or
@@ -95,6 +110,14 @@ class EnterOp(Op):
     '''
     def __init__(self, name):
         super(EnterOp, self).__init__(name)
+        self._frame_name = None
+
+    def setFrameName(self, frame_name):
+        self.debugAssert(self._frame_name is None)
+        self._frame_name = frame_name
+
+    def getFrameName(self):
+        return self._frame_name
 
     def propagateShapes(self, make_symbolic=False):
         # EnterOps should forward their inputs to their outputs

--- a/catamount/ops/subgraph_op.py
+++ b/catamount/ops/subgraph_op.py
@@ -18,6 +18,10 @@ class SubgraphOp(Op):
         # (i.e., terminal node) or they are consumed by other ops outside
         # the graph, then it is a sink op.
         self._sinks = {}
+        # The ContextFrame that is associated with this subgraph. The
+        # ContextFrame tracks the ops that gate the flow of tensors into
+        # the subgraph.
+        self._context_frame = None
 
         for op in ops_list:
             self.addOp(op)
@@ -138,6 +142,10 @@ class SubgraphOp(Op):
                 for consumer in out_tensor.consumers.values():
                     to_return.add(out_tensor)
         return list(to_return)
+
+    def setContextFrame(self, context_frame):
+        self.debugAssert(self._context_frame is None)
+        self._context_frame = context_frame
 
     def outputShapeIllDefined(self):
         # Subgraph ops are collections of other ops. Ignore whether subgraph


### PR DESCRIPTION
Previously, we were ad-hoc handling subgraphs as a collection of ops. This handling was sufficient for initial tests, but to add clearer subgraph delineation for traversals, we need to make sure we include absolutely every op that is inside a context (e.g., context = while loop or if statement). This PR adds the context to track the EnterOps that control/gate tensors flowing into the context and makes it easier to detect all the downstream ops that are within the context.
