### PR TITLE
Stack Ops: Add initial working implementation

### DIFF
--- a/catamount/frameworks/tensorflow.py
+++ b/catamount/frameworks/tensorflow.py
@@ -161,6 +161,9 @@ TF_OP_TO_CATAMOUNT = {
     'Sum': ReduceOp,
     'Square': SquareOp,
     'Squeeze': SqueezeOp,
+    'StackPopV2': StackPopOp,
+    'StackPushV2': StackPushOp,
+    'StackV2': StackOp,
     'StopGradient': StopGradientOp,
     'Switch': SwitchOp,
     'Tanh': TanhOp,
@@ -465,6 +468,7 @@ def construct_catamount_graph(tf_sess, tf_graph):
     tensors = {}
     op_inputs = {}
     ctrl_frames = {}
+    all_stack_ops = []
     for tf_op in tf_graph._nodes_by_name.values():
         if tf_op.type in TF_OP_TO_CATAMOUNT.keys():
             # Map to Catamount op type
@@ -529,11 +533,13 @@ def construct_catamount_graph(tf_sess, tf_graph):
         # Get the tf_op's attributes and set them as necessary
         parse_tf_op_attributes_into_op(tf_sess, tf_op, op)
 
-        if catamount_type == EnterOp:
+        if isinstance(op, EnterOp):
             frame_name = op.getFrameName()
             if frame_name not in ctrl_frames:
                 ctrl_frames[frame_name] = ContextFrame(frame_name)
             ctrl_frames[frame_name].addEnterOp(op)
+        elif isinstance(op, StackOp):
+            all_stack_ops.append(op)
 
         graph.addOp(op)
 
@@ -544,6 +550,23 @@ def construct_catamount_graph(tf_sess, tf_graph):
             assert in_tensor in tensors.keys(), \
                    'Unknown input tensor {}'.format(in_tensor)
             graph.addInputToOp(op, tensors[in_tensor])
+
+    # Propagate stack pointers for StackOps. These ops always occur as a
+    # series of ops. The StackOp is first, and propagates its' outputs to
+    # (optionally) EnterOps, and then to StackPush and StackPop ops. The
+    # StackPush and StackPop ops need to get the pointer for the stack
+    # created for the StackOp
+    for stack_op in all_stack_ops:
+        # Traverse out tensor to find all StackPush and StackPop
+        out_tensor = stack_op.outputs[0]
+        for cons_op in out_tensor.consumers.values():
+            while not isinstance(cons_op, BaseStackOp):
+                assert(isinstance(cons_op, (EnterOp, SwitchOp)))
+                assert(len(cons_op.outputs[0].consumers) == 1)
+                cons_ops = list(cons_op.outputs[0].consumers.values())
+                cons_op = cons_ops[0]
+            cons_op.setStack(stack_op.getStack())
+            assert(cons_op.getStack() is not None)
 
     # Remove any Tensorflow model saver ops from the graph. These ops
     # always occur as a series of 6 ops:

--- a/catamount/frameworks/tensorflow.py
+++ b/catamount/frameworks/tensorflow.py
@@ -552,7 +552,7 @@ def construct_catamount_graph(tf_sess, tf_graph):
             graph.addInputToOp(op, tensors[in_tensor])
 
     # Propagate stack pointers for StackOps. These ops always occur as a
-    # series of ops. The StackOp is first, and propagates its' outputs to
+    # series of ops. The StackOp is first, and propagates its outputs to
     # (optionally) EnterOps, and then to StackPush and StackPop ops. The
     # StackPush and StackPop ops need to get the pointer for the stack
     # created for the StackOp

--- a/catamount/graph/__init__.py
+++ b/catamount/graph/__init__.py
@@ -172,7 +172,7 @@ class Graph(SubgraphOp):
                       .format(op_search_str))
 
     def bindShapesAndPropagate(self, bind_dict, warn_if_ill_defined=False,
-                               make_symbolic=False):
+                               make_symbolic=False, verbose=False):
         ''' Bind the tensor dimensions as defined in the bind_dict, and then
             propagate those dimensions through the graph.
 
@@ -192,7 +192,8 @@ class Graph(SubgraphOp):
         '''
         self.bindOpShapeDimensions(bind_dict, make_symbolic=make_symbolic)
         self.propagateTensorShapeNames(warn_if_ill_defined,
-                                       make_symbolic=make_symbolic)
+                                       make_symbolic=make_symbolic,
+                                       verbose=True)
 
 
 # The Catamount default graph is used throughout the API

--- a/catamount/graph/__init__.py
+++ b/catamount/graph/__init__.py
@@ -193,7 +193,7 @@ class Graph(SubgraphOp):
         self.bindOpShapeDimensions(bind_dict, make_symbolic=make_symbolic)
         self.propagateTensorShapeNames(warn_if_ill_defined,
                                        make_symbolic=make_symbolic,
-                                       verbose=True)
+                                       verbose=verbose)
 
 
 # The Catamount default graph is used throughout the API

--- a/catamount/ops/__init__.py
+++ b/catamount/ops/__init__.py
@@ -9,6 +9,7 @@ from .math_ops import *
 from .optimizer_ops import *
 from .placeholder import *
 from .random_ops import *
+from .stack_ops import *
 from .subgraph_op import *
 from .tensor_array_ops import *
 from .unknown_op import *

--- a/catamount/ops/stack_ops.py
+++ b/catamount/ops/stack_ops.py
@@ -132,7 +132,7 @@ class StackPopOp(BaseStackOp):
         self.debugAssert(self._stack._reference is not None)
         in_tensor = self._stack._reference
         in_shape = in_tensor.shape
-        self._outputs[0].mergeShape(in_shape)
+        self._outputs[0].mergeShape(in_shape, make_symbolic=make_symbolic)
 
         if in_tensor.value is not None:
             self._outputs[0].setValue(in_tensor.value)
@@ -152,7 +152,7 @@ class StackPushOp(BaseStackOp):
         self.debugAssert(len(self._outputs) == 1)
 
         in_shape = self._inputs[1].shape
-        self._outputs[0].mergeShape(in_shape)
+        self._outputs[0].mergeShape(in_shape, make_symbolic=make_symbolic)
 
         if self._inputs[1].value is not None:
             self._outputs[0].setValue(self._inputs[1].value)

--- a/catamount/ops/stack_ops.py
+++ b/catamount/ops/stack_ops.py
@@ -1,0 +1,154 @@
+from .base_op import Op
+from catamount.tensors.tensor import Tensor
+
+
+class TensorStack:
+    ''' An object to be shared among Stack ops to push and pop tensor handles
+    for dynamic execution.
+    '''
+    def __init__(self):
+        self._tensor_stack = []
+        self._parent = None
+        self._push = None
+        self._pop = None
+        # The tensor reference that will be pushed into the stack
+        self._reference = None
+
+    def __len__(self):
+        return len(self._tensor_stack)
+
+    def isValid(self):
+        return self._parent is not None and \
+               self._push is not None and \
+               self._pop is not None
+
+    def associateStackOp(self, stack_op):
+        self._parent = stack_op
+
+    def associatePush(self, push_op):
+        self._push = push_op
+
+    def associatePop(self, pop_op):
+        self._pop = pop_op
+
+    @property
+    def name(self):
+        return self._parent.name
+
+    def addReferenceTensor(self, tensor):
+        self._reference = tensor
+
+    def push(self, tensor):
+        assert isinstance(tensor, Tensor)
+        self._tensor_stack.insert(0, tensor)
+
+    def peek(self):
+        if len(self._tensor_stack) == 0:
+            return None
+        else:
+            return self._tensor_stack[0]
+
+
+class BaseStackOp(Op):
+    def __init__(self, name):
+        super(BaseStackOp, self).__init__(name)
+        # The stack reference to use for pushing and popping
+        self._stack = None
+
+    def debugString(self):
+        to_return = super(BaseStackOp, self).debugString()
+        to_return += '\n  Stack: {}'.format(self._stack.name)
+        return to_return
+
+    def setStack(self, stack):
+        self.debugAssert(self._stack is None)
+        self._stack = stack
+        if isinstance(self, StackPushOp):
+            assert(self._stack._reference is None)
+            self._stack.associatePush(self)
+            self._stack.addReferenceTensor(self.outputs[0])
+
+    def getStack(self):
+        return self._stack
+
+    def calcAlgFlops(self):
+        # Stack operations have no Flops
+        return 0
+
+    def calcAlgBytes(self):
+        # Stack operations do not perform algorithmic activity,
+        # so accessed memory is not algorithmic
+        return 0
+
+    def calcAlgFootprint(self):
+        # Stack operations do not perform algorithmic activity,
+        # so accessed memory is not algorithmic
+        return 0
+
+
+class StackOp(BaseStackOp):
+    def __init__(self, name):
+        super(StackOp, self).__init__(name)
+        self._stack = TensorStack()
+        self._stack.associateStackOp(self)
+
+    def isValid(self):
+        return self._stack.isValid() and super(StackOp, self).isValid()
+
+    def propagateShapes(self, make_symbolic=False):
+        # Zero or one inputs. First input is the maximum depth of the stack
+        self.debugAssert(len(self._inputs) <= 1)
+        self.debugAssert(len(self._outputs) == 1)
+        # The output is a resource handle of shape [Dimension(2)]
+        self.debugAssert(self._outputs[0].shape.rank == 1 and
+                         self._outputs[0].shape.numElements() == 2)
+
+
+class StackPopOp(BaseStackOp):
+    def __init__(self, name):
+        super(StackPopOp, self).__init__(name)
+
+    def setStack(self, stack):
+        super(StackPopOp, self).setStack(stack)
+        self._stack.associatePop(self)
+
+    def canVisit(self, visited_ops):
+        self.debugAssert(self._stack._reference is not None)
+        stack_push_op = self._stack._reference.producer
+        self.debugAssert(stack_push_op == self._stack._push)
+        self.debugAssert(isinstance(stack_push_op, StackPushOp))
+        print('\n\nStackPopOp canVisit: {}\n  VISITED: {}\n\n'.format(self.debugString(), [op.name for op in visited_ops]))
+        if stack_push_op not in visited_ops:
+            return False
+        return super(StackPopOp, self).canVisit(visited_ops)
+
+    def propagateShapes(self, make_symbolic=False):
+        self.debugAssert(len(self._inputs) == 1)
+        self.debugAssert(len(self._outputs) == 1)
+
+        self.debugAssert(self._stack._reference is not None)
+        in_tensor = self._stack._reference
+        in_shape = in_tensor.shape
+        self._outputs[0].mergeShape(in_shape)
+
+        if in_tensor.value is not None:
+            self._outputs[0].setValue(in_tensor.value)
+
+
+class StackPushOp(BaseStackOp):
+    def __init__(self, name):
+        super(StackPushOp, self).__init__(name)
+
+    def canVisit(self, visited_ops):
+        print('StackPushOp canVisit: {}\n  VISITED: {}\n\n'.format(self.debugString(), [op.name for op in visited_ops]))
+        return super(StackPushOp, self).canVisit(visited_ops)
+
+    def propagateShapes(self, make_symbolic=False):
+        self.debugAssert(len(self._inputs) == 2)
+        self.debugAssert(len(self._outputs) == 1)
+
+        in_shape = self._inputs[1].shape
+        self._outputs[0].mergeShape(in_shape)
+
+        if self._inputs[1].value is not None:
+            self._outputs[0].setValue(self._inputs[1].value)

--- a/catamount/ops/subgraph_op.py
+++ b/catamount/ops/subgraph_op.py
@@ -3,7 +3,7 @@ from .base_op import Op
 from ..api import utils
 
 # HACK: Remove me later
-from .stack_ops import StackPushOp, StackPopOp
+from .stack_ops import StackPushOp
 
 
 class SubgraphOp(Op):

--- a/catamount/ops/subgraph_op.py
+++ b/catamount/ops/subgraph_op.py
@@ -255,34 +255,16 @@ class SubgraphOp(Op):
             raise NotImplementedError(
                 'Implement getTopologicalOpOrder to take fetches')
 
-        print('-----------\nENTERING SUBGRAPH: {}\n.... HIERARCHICAL: {}'.format(self.debugString(), hierarchical))
-
         topo_ordered_ops = []
         op_inputs_visited = {}
         frontier_ops = set()
         visited_ops = set()
-
-        # HAXXX! TOTAL HACKS TO TEST THAT THIS WILL WORK
-        for op in self._ops_by_name.values():
-            if isinstance(op, StackPopOp) and op.parent == self:
-                stack_push_op = op._stack._push
-                self.debugAssert(stack_push_op.parent != self)
-                if op not in op_inputs_visited:
-                    op_inputs_visited[op] = set()
-                op_inputs_visited[op].add(stack_push_op)
-                visited_ops.add(stack_push_op)
-                print('PRIMING STACKPOP: {}\n.... WITH PUSH: {}'.format(op.debugString(), stack_push_op.name))
-        # HAXXX! TOTAL HACKS TO TEST THAT THIS WILL WORK
-
         # Prime the frontier with source ops
         # TODO (Joel): Could set frontier equal to feed_dict?
         for source_op in self._sources.values():
             self.debugAssert(source_op.parent == self)
-#            TODO: REVERT TO THIS AFTER REMOVING HAXXX!
-#            self.debugAssert(source_op not in op_inputs_visited)
-#            op_inputs_visited[source_op] = set()
-            if source_op not in op_inputs_visited:
-                op_inputs_visited[source_op] = set()
+            self.debugAssert(source_op not in op_inputs_visited)
+            op_inputs_visited[source_op] = set()
             for in_tensor in source_op.inputs:
                 self.debugAssert(self.parent is not None)
                 # If the producer op is not from this subgraph, it needs
@@ -295,7 +277,6 @@ class SubgraphOp(Op):
         # Continually visit frontier ops until none left
         while len(frontier_ops) > 0:
             next_op = frontier_ops.pop()
-            print('VISITING: {}'.format(next_op.debugString()))
             self.debugAssert(next_op.canVisit(visited_ops),
                              'Next op {} cannot visit. Visited: {}'
                              .format(next_op.name, visited_ops))
@@ -303,9 +284,7 @@ class SubgraphOp(Op):
                 topo_ordered_ops.append(next_op)
             visited_ops.add(next_op)
             for out_tensor in next_op.outputs:
-                print('    VISITING OUT: {}'.format(out_tensor))
                 for consumer in out_tensor.consumers.values():
-                    print('        VISITING CONS: {}'.format(consumer.name))
                     if consumer in visited_ops:
                         continue
                     if consumer not in op_inputs_visited:
@@ -320,13 +299,6 @@ class SubgraphOp(Op):
                             producer_op = out_tensor.producer
                             visited_ops.add(producer_op)
                     op_inputs_visited[consumer].add(producer_op)
-
-                    # TODO: REMOVE ME
-                    from .ctrl_ops import EnterOp
-                    if isinstance(consumer, (StackPushOp, EnterOp)):
-                        print('TRYING TO VISIT STACKPUSH OR ENTER: {}'.format(consumer.debugString()))
-                    # TODO: REMOVE ME
-
                     # Check if the consumer can now be visited, and if so,
                     # add it to the frontier
                     if consumer.canVisit(op_inputs_visited[consumer]):
@@ -344,7 +316,6 @@ class SubgraphOp(Op):
             # frontier.
             # TODO: Replace this check with control dependencies?
             if isinstance(next_op, StackPushOp):
-                print('CHECKING TO VISIT ASSOCIATED STACK POP. PUSH {}'.format(next_op))
                 stack_pop_op = next_op._stack._pop
                 self.debugAssert(stack_pop_op not in visited_ops)
                 if stack_pop_op not in op_inputs_visited:
@@ -505,9 +476,6 @@ class SubgraphOp(Op):
                 if in_tensor.producer.parent != self:
                     assert in_tensor.producer not in self._ops_by_name.keys()
                     my_visited_ops.add(in_tensor.producer)
-            # HAXXX: TOTAL HACKS TO GET THIS TO RUN
-            if isinstance(op, StackPopOp) and op.parent == self:
-                my_visited_ops.add(op._stack._push)
         my_max_footprint = max_footprint
         my_curr_footprint = curr_footprint
         for op in ops_to_execute:

--- a/catamount/ops/subgraph_op.py
+++ b/catamount/ops/subgraph_op.py
@@ -2,6 +2,9 @@ import sympy
 from .base_op import Op
 from ..api import utils
 
+# HACK: Remove me later
+from .stack_ops import StackPushOp
+
 
 class SubgraphOp(Op):
     ''' A SubgraphOp designates a subgraph that manages a collection of ops.
@@ -274,6 +277,7 @@ class SubgraphOp(Op):
         # Continually visit frontier ops until none left
         while len(frontier_ops) > 0:
             next_op = frontier_ops.pop()
+            print('VISITING: {}'.format(next_op.debugString()))
             self.debugAssert(next_op.canVisit(visited_ops),
                              'Next op {} cannot visit. Visited: {}'
                              .format(next_op.name, visited_ops))
@@ -291,13 +295,16 @@ class SubgraphOp(Op):
                     # producer needs to be added to visited_ops.
                     producer_op = next_op
                     if next_op != out_tensor.producer:
-                        self.debugAssert(next_op, SubgraphOp)
+                        self.debugAssert(isinstance(next_op, SubgraphOp))
                         if hierarchical:
                             producer_op = out_tensor.producer
                             visited_ops.add(producer_op)
                     op_inputs_visited[consumer].add(producer_op)
                     # Check if the consumer can now be visited, and if so,
                     # add it to the frontier
+                    from .ctrl_ops import EnterOp
+                    if isinstance(consumer, (StackPushOp, EnterOp)):
+                        print('TRYING TO VISIT STACKPUSH OR ENTER: {}'.format(consumer.debugString()))
                     if consumer.canVisit(op_inputs_visited[consumer]):
                         if not hierarchical or consumer.parent == self:
                             frontier_ops.add(consumer)
@@ -307,6 +314,25 @@ class SubgraphOp(Op):
                        consumer.parent not in visited_ops:
                         if consumer.parent.canVisit(visited_ops):
                             frontier_ops.add(consumer.parent)
+            # ----------------------------------------------------------------
+            # HACK! StackPushOps need to signal that the corresponding
+            # StackPopOp may now be ready to visit. If so, add it to the
+            # frontier.
+            # TODO: REPLACE THIS CHECK WITH CONTROL DEPENDENCIES?
+            if isinstance(next_op, StackPushOp):
+                import pdb
+                pdb.set_trace()
+                stack_pop_op = next_op._stack._pop
+                self.debugAssert(stack_pop_op not in visited_ops)
+                if stack_pop_op not in op_inputs_visited:
+                    op_inputs_visited[stack_pop_op] = set()
+                # Signal that the stack has been visited by adding the
+                # StackPushOp to the StackPopOp's visited inputs
+                op_inputs_visited[stack_pop_op].add(next_op)
+                if stack_pop_op.canVisit(op_inputs_visited[stack_pop_op]):
+                    if not hierarchical or stack_pop_op.parent == self:
+                        frontier_ops.add(stack_pop_op)
+            # ----------------------------------------------------------------
         # print('Subgraph: {}'.format(self.name))
         # print('All ops: {}'.format(len(self._ops_by_name.keys())))
         children_ops = set()

--- a/catamount/tests/full/tf_dynamic_rnn_with_backprop.py
+++ b/catamount/tests/full/tf_dynamic_rnn_with_backprop.py
@@ -138,30 +138,6 @@ def test_tf_dynamic_rnn():
                   'Gradient/Compute/gradients/rnn/while/basic_lstm_cell/BiasAdd/Enter_grad/b_acc': [4 * hidden_dim],
                 }
     graph.bindShapesAndPropagate(bind_dict, make_symbolic=True, warn_if_ill_defined=True)
-    # Finally, more hacking... StackPops can pull from their corresponding
-    # StackPushs. Try to propagate their shapes and/or values if possible
-    # NOTE: This code is pretty general and is likely to be migrated into
-    # Catamount ops for stacks later
-    for op in graph._ops_by_name.values():
-        op_name_split = op.name.split('/')
-        if 'StackPop' in op_name_split[-1]:
-            push_name_split = list(op_name_split)
-            push_name_split[-1] = push_name_split[-1].replace('StackPop',
-                                                              'StackPush')
-            push_name = '/'.join(push_name_split)
-            if push_name not in graph._ops_by_name.keys():
-                print('WARN: CANNOT FIND CORRESPONDING STACK PUSH: {}'
-                      .format(push_name))
-                continue
-            push_op = graph._ops_by_name[push_name]
-            # Verify StackPush input[1].shape == StackPop output[0].shape
-            assert push_op._inputs[1].shape == op._outputs[0].shape
-            op._outputs[0].mergeShape(push_op._inputs[1].shape, make_symbolic=True)
-            if push_op._inputs[1].value is not None:
-                op._outputs[0].setValue(push_op._inputs[1].value)
-
-    # Bind and propagate again now that StackPops have correct shapes/values
-    graph.bindShapesAndPropagate(bind_dict, make_symbolic=True, warn_if_ill_defined=True)
 
     algorithmic_flops = graph.calcAlgFlops()
 
@@ -206,7 +182,7 @@ def test_tf_dynamic_rnn():
 
     assert graph.isValid()
 
-    print('BOUND GRAPH: {}\n\n'.format(graph))
+    print('BOUND GRAPH:\n{}\n\n'.format(graph))
 
     print('Bound Flops test:')
     print('    Catamount:   {}'.format(algorithmic_flops))

--- a/catamount/tests/full/tf_dynamic_rnn_with_backprop.py
+++ b/catamount/tests/full/tf_dynamic_rnn_with_backprop.py
@@ -121,8 +121,6 @@ def test_tf_dynamic_rnn():
                  }
     graph.bindConstantValues(const_dict)
 
-    # Bind first to get StackPush inputs
-    # TODO (Joel): Fix this up when all stack ops work!
     # NOTE: This also works: batch_size = 'batch_size'
     # Bind placeholders (a and b) output dimensions 0 to name batch_size
     bind_dict = { # Variables

--- a/catamount/tests/full/tf_language_models.py
+++ b/catamount/tests/full/tf_language_models.py
@@ -152,18 +152,11 @@ def run_tf_language_model(domain=None, build_projection=False):
     else:
         raise NotImplementedError('ERROR: Unknown domain: {}'.format(domain))
 
-    # HAXXX: Manually setting TensorArray and StackPop shapes!
+    # HAXXX: Manually setting TensorArray shapes!
     if domain == 'wordlm' or domain == 'charlm' or domain == 'nmt':
         for op in graph._ops_by_name.values():
             op_name_suffix = op.name.split('/')[-1]
-            if 'StackPop' in op_name_suffix:
-                # HAXXXX: Just verify op structure. Pull shapes and values
-                # from corresponding StackPush ops below
-                assert isinstance(op, UnknownOp)
-                assert len(op._inputs) == 1
-                assert len(op._outputs) == 1
-                continue
-            elif 'TensorArrayGather' in op_name_suffix:
+            if 'TensorArrayGather' in op_name_suffix:
                 assert isinstance(op, UnknownOp)
                 assert len(op._inputs) == 3
                 assert len(op._outputs) == 1

--- a/catamount/tests/full/tf_speech_attention.py
+++ b/catamount/tests/full/tf_speech_attention.py
@@ -249,12 +249,6 @@ def run_tf_speech_attention():
                              num_conv_filters_symbol]
             if out_shape is not None:
                 op._outputs[0].mergeShape(out_shape, make_symbolic=True)
-        elif 'StackPop' in op_name_suffix:
-            # StackPop ops are handled below by pulling shapes from the resolved
-            # dimensions of StackPush ops. Just verify inputs and outputs
-            assert isinstance(op, UnknownOp)
-            assert len(op._inputs) == 1
-            assert len(op._outputs) == 1
         elif 'TensorArrayGather' in op_name_suffix:
             assert isinstance(op, UnknownOp)
             assert len(op._inputs) == 3

--- a/catamount/tests/full/tf_speech_attention.py
+++ b/catamount/tests/full/tf_speech_attention.py
@@ -234,21 +234,6 @@ def run_tf_speech_attention():
     # or Stack ops. Here, manually set the dimensions of these ops' tensors.
     for op in graph._ops_by_name.values():
         op_name_suffix = op.name.split('/')[-1]
-#        if 'StackPush' in op_name_suffix:
-#            assert len(op._inputs) == 2
-#            assert len(op._outputs) == 1
-#            out_shape = None
-#            if len(op._outputs[0].consumers) > 0:
-#                print('TODO: StackPush should prop shapes: {}'
-#                      .format(op.debugString()))
-#            if op.name == 'attn_model/AttentionModel/gradients/attn_model/Decoder/while/attn_model/conv1d_1/Conv2D_grad/ShapeN/StackPushV2_1':
-#                out_shape = [1, 1, num_conv_filters_symbol, attn_dim_symbol]
-#            elif op.name == 'attn_model/AttentionModel/gradients/attn_model/Decoder/while/attn_model/conv1d_1/Conv2D_grad/ShapeN/StackPushV2':
-#                out_shape = [subbatch_size_symbol, 1,
-#                             (encoder_steps_symbol // 2) // 2,
-#                             num_conv_filters_symbol]
-#            if out_shape is not None:
-#                op._outputs[0].mergeShape(out_shape, make_symbolic=True)
         if 'TensorArrayGather' in op_name_suffix:
             assert isinstance(op, UnknownOp)
             assert len(op._inputs) == 3


### PR DESCRIPTION
When tracking activation tensors for backpropping while loops, we need a data structure to collect the activations. Tensorflow uses stacks, which are comprised of a StackOp that tracks the stack data structure reference, a StackPush op that adds activations to the stack, and a StackPop op that pulls activations from the stack during backprop.

This PR adds stacks that function like Tensorflow stacks, and fixes the stack tensor handling hacks that existed in the full TF tests: language models and the speech model.