### PR TITLE
Graph Saver: Add a simple interface to save and load graphs

### DIFF
--- a/catamount/graph/__init__.py
+++ b/catamount/graph/__init__.py
@@ -1,9 +1,8 @@
 import re
 from catamount.ops.base_op import Op
 from catamount.ops.constant import ConstantOp
-from catamount.ops.subgraph_op import SubgraphOp
-from catamount.ops.constant import ConstantOp
 from catamount.ops.placeholder import PlaceholderOp
+from catamount.ops.subgraph_op import SubgraphOp
 from catamount.ops.variable import VariableOp
 
 

--- a/catamount/graph/saver.py
+++ b/catamount/graph/saver.py
@@ -1,15 +1,20 @@
 import pickle
+import sys
+# Very large compute graphs require that Python recurses the pointer chain
+# to depths upward of 10000 (Python default is only 1000)
+sys.setrecursionlimit(50000)
 
 
 def saveGraph(graph, path):
-    if '.ccg$' not in path:
+    if path.split('.')[-1] != 'ccg':
         print('WARN: Catamount graphs should save to .ccg filenames')
     # Hacky way to store graphs for now
+    # TODO: Change this to a protobuf implementation
     with open(path, 'wb') as outfile:
         pickle.dump(graph, outfile)
 
 def loadGraph(path):
-    if '.ccg$' not in path:
+    if path.split('.')[-1] != 'ccg':
         print('WARN: Catamount graphs should have .ccg filenames')
     # Hacky way to load pickled graphs for now
     with open(path, 'rb') as infile:

--- a/catamount/graph/saver.py
+++ b/catamount/graph/saver.py
@@ -1,0 +1,17 @@
+import pickle
+
+
+def saveGraph(graph, path):
+    if '.ccg$' not in path:
+        print('WARN: Catamount graphs should save to .ccg filenames')
+    # Hacky way to store graphs for now
+    with open(path, 'wb') as outfile:
+        pickle.dump(graph, outfile)
+
+def loadGraph(path):
+    if '.ccg$' not in path:
+        print('WARN: Catamount graphs should have .ccg filenames')
+    # Hacky way to load pickled graphs for now
+    with open(path, 'rb') as infile:
+        graph = pickle.load(infile)
+    return graph


### PR DESCRIPTION
To use this interface, simply construct a graph, then save it with:
```
import catamount.graph.saver as saver
saver.saveGraph(graph, 'path_to_graph.ccg')
```
Then, to load the saved graph:
```
graph = saver.loadGraph('path_to_graph.ccg')
```
