### PR TITLE
Framework: Tensorflow: Remove initialization ops by default

### DIFF
--- a/catamount/tests/full/tf_dynamic_rnn_with_backprop.py
+++ b/catamount/tests/full/tf_dynamic_rnn_with_backprop.py
@@ -10,28 +10,6 @@ tf_example_filename = 'catamount/frameworks/example_graphs/tensorflow/rnn/output
 def test_tf_dynamic_rnn():
     graph = catamount.frameworks.tensorflow.import_graph(tf_example_filename)
 
-    # ============ TO REMOVE INITIALIZATION OPS! =============
-    # NOTE: This code is pretty general and is likely to be migrated into
-    # Catamount code for removing TF-specific initialization ops
-    from catamount.ops import AssignOp
-    from catamount.ops import VariableOp
-    assign_ops = set()
-    for op in graph.opsByName.values():
-        if isinstance(op, AssignOp):
-            assign_ops.add(op)
-    for assign_op in assign_ops:
-        my_ancestors = set()
-        my_frontier = set()
-        my_frontier.add(assign_op)
-        while len(my_frontier) > 0:
-            next_op = my_frontier.pop()
-            for in_tensor in next_op.inputs:
-                if not isinstance(in_tensor.producer, VariableOp):
-                    my_frontier.add(in_tensor.producer)
-            my_ancestors.add(next_op)
-        for next_op in my_ancestors:
-            graph.removeOp(next_op)
-
     print('INITIAL GRAPH: {}\n\n'.format(graph))
 
     assert graph.isValid()

--- a/catamount/tests/full/tf_image_resnet.py
+++ b/catamount/tests/full/tf_image_resnet.py
@@ -66,29 +66,6 @@ def run_tf_image_resnet(depth, filter_scale=1.0):
     graph = catamount.frameworks.tensorflow.import_graph(graph_meta)
     assert graph.isValid()
 
-    # ============ TO REMOVE INITIALIZATION OPS! =============
-    # NOTE: This code is pretty general and is likely to be migrated into
-    # Catamount code for removing TF-specific initialization ops
-    from catamount.ops import AssignOp
-    from catamount.ops import VariableOp
-    assign_ops = set()
-    for op in graph.opsByName.values():
-        if isinstance(op, AssignOp):
-            assign_ops.add(op)
-    for assign_op in assign_ops:
-        my_ancestors = set()
-        my_frontier = set()
-        my_frontier.add(assign_op)
-        while len(my_frontier) > 0:
-            next_op = my_frontier.pop()
-            for in_tensor in next_op.inputs:
-                if not isinstance(in_tensor.producer, VariableOp):
-                    my_frontier.add(in_tensor.producer)
-            my_ancestors.add(next_op)
-        for next_op in my_ancestors:
-            graph.removeOp(next_op)
-    assert graph.isValid()
-
     # Manually remove the inference parts of graph
     graph_ops = list(graph._ops_by_name.values())
     for op in graph_ops:

--- a/catamount/tests/full/tf_language_models.py
+++ b/catamount/tests/full/tf_language_models.py
@@ -48,29 +48,6 @@ def run_tf_language_model(domain=None, build_projection=False):
     graph = catamount.frameworks.tensorflow.import_graph(graph_meta)
     assert graph.isValid()
 
-    # ============ TO REMOVE INITIALIZATION OPS! =============
-    # NOTE: This code is pretty general and is likely to be migrated into
-    # Catamount code for removing TF-specific initialization ops
-    from catamount.ops import AssignOp
-    from catamount.ops import VariableOp
-    assign_ops = set()
-    for op in graph.opsByName.values():
-        if isinstance(op, AssignOp):
-            assign_ops.add(op)
-    for assign_op in assign_ops:
-        my_ancestors = set()
-        my_frontier = set()
-        my_frontier.add(assign_op)
-        while len(my_frontier) > 0:
-            next_op = my_frontier.pop()
-            for in_tensor in next_op.inputs:
-                if not isinstance(in_tensor.producer, VariableOp):
-                    my_frontier.add(in_tensor.producer)
-            my_ancestors.add(next_op)
-        for next_op in my_ancestors:
-            graph.removeOp(next_op)
-    assert graph.isValid()
-
     # Next, remove ops that are not executed during a standard training step:
     # TODO: Implement feeds->fetches calcAlg*
     if domain == 'wordlm':

--- a/catamount/tests/full/tf_speech_attention.py
+++ b/catamount/tests/full/tf_speech_attention.py
@@ -26,28 +26,6 @@ def run_tf_speech_attention():
     graph = catamount.frameworks.tensorflow.import_graph(graph_meta)
     assert graph.isValid()
 
-    # ============ TO REMOVE INITIALIZATION OPS! =============
-    # NOTE: This code is pretty general and is likely to be migrated into
-    # Catamount code for removing TF-specific initialization ops
-    from catamount.ops import AssignOp
-    from catamount.ops import VariableOp
-    assign_ops = set()
-    for op in graph.opsByName.values():
-        if isinstance(op, AssignOp):
-            assign_ops.add(op)
-    for assign_op in assign_ops:
-        my_ancestors = set()
-        my_frontier = set()
-        my_frontier.add(assign_op)
-        while len(my_frontier) > 0:
-            next_op = my_frontier.pop()
-            for in_tensor in next_op.inputs:
-                if not isinstance(in_tensor.producer, VariableOp):
-                    my_frontier.add(in_tensor.producer)
-            my_ancestors.add(next_op)
-        for next_op in my_ancestors:
-            graph.removeOp(next_op)
-
     # HAX: NEED TO MANUALLY REMOVE SOME?! WHY?
     remove_ops = ['DevArgmaxWERChecker/Less', 'DevLossChecker/Less', 'DevArgmaxWERChecker/best_dev', 'DevLossChecker/best_dev']
     for op_name in remove_ops:

--- a/catamount/tests/full/tf_word2vec.py
+++ b/catamount/tests/full/tf_word2vec.py
@@ -28,29 +28,6 @@ def run_tf_w2v_model():
     graph = catamount.frameworks.tensorflow.import_graph(graph_meta)
     assert graph.isValid()
 
-    # ============ TO REMOVE INITIALIZATION OPS! =============
-    # NOTE: This code is pretty general and is likely to be migrated into
-    # Catamount code for removing TF-specific initialization ops
-    from catamount.ops import AssignOp
-    from catamount.ops import VariableOp
-    assign_ops = set()
-    for op in graph.opsByName.values():
-        if isinstance(op, AssignOp):
-            assign_ops.add(op)
-    for assign_op in assign_ops:
-        my_ancestors = set()
-        my_frontier = set()
-        my_frontier.add(assign_op)
-        while len(my_frontier) > 0:
-            next_op = my_frontier.pop()
-            for in_tensor in next_op.inputs:
-                if not isinstance(in_tensor.producer, VariableOp):
-                    my_frontier.add(in_tensor.producer)
-            my_ancestors.add(next_op)
-        for next_op in my_ancestors:
-            graph.removeOp(next_op)
-    assert graph.isValid()
-
     # Next, remove ops that are not executed during a standard training step:
     graph_ops = list(graph._ops_by_name.values())
     for op in graph_ops:


### PR DESCRIPTION
We just copied the ~same code across each of the TF full tests, so instead,
just remove the TF initialization ops as part of the initial graph loading.