### PR TITLE
Tensors: Make value handling more robust to shape differences

### DIFF
--- a/catamount/frameworks/tensorflow.py
+++ b/catamount/frameworks/tensorflow.py
@@ -368,8 +368,12 @@ def get_const_value_from_op(tf_sess, tf_op):
                 value = np.full(np_shape, value[0], dtype=float)
             else:
                 value = np.array(value)
+            if list(value.shape) != tf_op.outputs[0].shape.as_list():
+                value = np.reshape(value, tf_op.outputs[0].shape.as_list())
             assert list(value.shape) == tf_op.outputs[0].shape.as_list(), \
-                'Op: {}, value: {}'.format(tf_op.name, value)
+                'Op: {}, value: {}, len(value): {}, out_shape: {}' \
+                .format(tf_op.name, value, list(value.shape),
+                        tf_op.outputs[0].shape.as_list())
     elif value_proto.dtype == types_pb2.DT_STRING:
         if tf_op.outputs[0].shape.ndims == 0 or \
            tf_op.outputs[0].shape.num_elements() == 1:

--- a/catamount/frameworks/tensorflow.py
+++ b/catamount/frameworks/tensorflow.py
@@ -368,8 +368,16 @@ def get_const_value_from_op(tf_sess, tf_op):
                 value = np.full(np_shape, value[0], dtype=float)
             else:
                 value = np.array(value)
-            if list(value.shape) != tf_op.outputs[0].shape.as_list():
-                value = np.reshape(value, tf_op.outputs[0].shape.as_list())
+            tf_op_shape_list = tf_op.outputs[0].shape.as_list()
+            if list(value.shape) != tf_op_shape_list:
+                try:
+                    value = np.reshape(value, tf_op_shape_list)
+                except ValueError as err:
+                    print('{}:\nShape mismatch. Value {}, shapes '\
+                          '{} != {}'.format(tf_op.name, value,
+                                            list(value.shape),
+                                            tf_op_shape_list))
+                    raise err
             assert list(value.shape) == tf_op.outputs[0].shape.as_list(), \
                 'Op: {}, value: {}, len(value): {}, out_shape: {}' \
                 .format(tf_op.name, value, list(value.shape),

--- a/catamount/tensors/tensor.py
+++ b/catamount/tensors/tensor.py
@@ -232,6 +232,9 @@ class Tensor:
                        value.dtype.kind in np_string_types, \
                     '{}:\nTrying to set value dtype to {}' \
                     .format(self, value.dtype)
+                if list(value.shape) != self._shape.asList():
+                    # Try to reshape if not already correct
+                    value = np.reshape(value, self._shape.asList())
                 assert list(value.shape) == self._shape.asList(), \
                     '{}:\nShape mismatch. Value {}, shapes {} != {}' \
                     .format(self, value, list(value.shape),

--- a/catamount/tensors/tensor.py
+++ b/catamount/tensors/tensor.py
@@ -234,7 +234,14 @@ class Tensor:
                     .format(self, value.dtype)
                 if list(value.shape) != self._shape.asList():
                     # Try to reshape if not already correct
-                    value = np.reshape(value, self._shape.asList())
+                    try:
+                        value = np.reshape(value, self._shape.asList())
+                    except ValueError as err:
+                        print('{}:\nShape mismatch. Value {}, shapes '\
+                              '{} != {}'.format(self, value,
+                                                list(value.shape),
+                                                self._shape.asList()))
+                        raise err
                 assert list(value.shape) == self._shape.asList(), \
                     '{}:\nShape mismatch. Value {}, shapes {} != {}' \
                     .format(self, value, list(value.shape),


### PR DESCRIPTION
In more recent versions of Tensorflow, tensor storage in checkpoint files is
often flattened and then reshaped as the tensor is read (probably protobuf
optimization?). Try reshaping the tensor values if they do not match the
intended tensor shape.