### PR TITLE
Tests: Fix some tests that had regressed

### DIFF
--- a/catamount/frameworks/tensorflow.py
+++ b/catamount/frameworks/tensorflow.py
@@ -662,7 +662,7 @@ def construct_catamount_graph(tf_sess, tf_graph):
                    'Not ident or unk: {}'.format(input_op.debugString())
                 parent_ops_to_trace_and_remove.append(input_op)
             else:
-                assert isinstance(input_op, ConstantOp), \
+                assert isinstance(input_op, (ConstantOp, IdentityOp)), \
                    'Not const: {}'.format(input_op.debugString())
         while len(parent_ops_to_trace_and_remove) > 0:
             parent_op = parent_ops_to_trace_and_remove.pop(0)

--- a/catamount/tests/full/tf_dynamic_rnn.py
+++ b/catamount/tests/full/tf_dynamic_rnn.py
@@ -16,8 +16,7 @@ def test_tf_dynamic_rnn():
     mm_0 = utils.getIntSymbolFromString('rnn/while/basic_rnn_cell/MatMul:0::dim_0')
     th_0 = utils.getIntSymbolFromString('rnn/while/basic_rnn_cell/Tanh:0::dim_0')
     correct_alg_flops = rwb_iters * \
-                        (24 * ba_0 + 2304 * mm_0 + 144 * th_0 + 5) + \
-                        2305
+                        (24 * ba_0 + 2304 * mm_0 + 144 * th_0 + 5)
 
     print('Loaded Flops test:')
     print('    Catamount:   {}'.format(algorithmic_flops))

--- a/catamount/tests/full/tf_small_test.py
+++ b/catamount/tests/full/tf_small_test.py
@@ -17,7 +17,7 @@ def test_tf_load_and_calculate():
     correct_alg_flops = 256 * add_dim_0 + \
                         65536 * matmul_dim_0 + \
                         256 * mul_dim_0 + \
-                        98307
+                        1
 
     print('Loaded Flops test:')
     print('    Catamount:   {}'.format(algorithmic_flops))

--- a/catamount/tests/full/tf_static_unroll.py
+++ b/catamount/tests/full/tf_static_unroll.py
@@ -28,7 +28,7 @@ def test_tf_static_unroll_rnn():
     th_4 = utils.getIntSymbolFromString('basic_rnn_cell/Tanh_4:0::dim_0')
     correct_alg_flops = 24 * (ba_0 + ba_1 + ba_2 + ba_3 + ba_4) + \
                         2304 * (mm_0 + mm_1 + mm_2 + mm_3 + mm_4) + \
-                        144 * (th_0 + th_1 + th_2 + th_3 + th_4) + 2305
+                        144 * (th_0 + th_1 + th_2 + th_3 + th_4)
 
     print('Loaded Flops test:')
     print('    Catamount:   {}'.format(algorithmic_flops))

--- a/catamount/tests/run_tests.sh
+++ b/catamount/tests/run_tests.sh
@@ -5,19 +5,19 @@ echo -e "------------ Running ops tests ---------------\n\n"
 for testfile in `ls catamount/tests/ops/*.py`
 do
 	echo Running test: $testfile
-	python -m pytest $testfile
+	python -m pytest $testfile -p no:warnings
 done
 
 echo -e "\n\n------------ Running API tests ---------------\n\n"
 for testfile in `ls catamount/tests/api/*.py`
 do
 	echo Running test: $testfile
-	python -m pytest $testfile
+	python -m pytest $testfile -p no:warnings
 done
 
 echo -e "\n\n------------ Running full tests ---------------\n\n"
 for testfile in `ls catamount/tests/full/*.py`
 do
 	echo Running test: $testfile
-	python -m pytest $testfile
+	python -m pytest $testfile -p no:warnings
 done

--- a/catamount/tests/run_tests.sh
+++ b/catamount/tests/run_tests.sh
@@ -1,11 +1,21 @@
 #!/bin/bash
 
+testsfailed="0"
+failedtests=()
+testspassed="0"
 
 echo -e "------------ Running ops tests ---------------\n\n"
 for testfile in `ls catamount/tests/ops/*.py`
 do
 	echo Running test: $testfile
 	python -m pytest $testfile -p no:warnings
+	if [ "$?" != "0" ]
+	then
+		failedtests[$testsfailed]="$testfile"
+		testsfailed=$(($testsfailed + 1))
+	else
+		testspassed=$(($testspassed + 1))
+	fi
 done
 
 echo -e "\n\n------------ Running API tests ---------------\n\n"
@@ -13,6 +23,13 @@ for testfile in `ls catamount/tests/api/*.py`
 do
 	echo Running test: $testfile
 	python -m pytest $testfile -p no:warnings
+	if [ "$?" != "0" ]
+	then
+		failedtests[$testsfailed]="$testfile"
+		testsfailed=$(($testsfailed + 1))
+	else
+		testspassed=$(($testspassed + 1))
+	fi
 done
 
 echo -e "\n\n------------ Running full tests ---------------\n\n"
@@ -20,4 +37,20 @@ for testfile in `ls catamount/tests/full/*.py`
 do
 	echo Running test: $testfile
 	python -m pytest $testfile -p no:warnings
+	if [ "$?" != "0" ]
+	then
+		failedtests[$testsfailed]="$testfile"
+		testsfailed=$(($testsfailed + 1))
+	else
+		testspassed=$(($testspassed + 1))
+	fi
+done
+
+echo -e "\n\n------------ Tests summary ---------------\n\n"
+totaltests=$(($testsfailed + $testspassed))
+echo "Tests passed: $testspassed"
+echo "Tests failed: $testsfailed"
+for i in "${failedtests[@]}"
+do
+	echo "        $i"
 done


### PR DESCRIPTION
- I missed a couple test updates when I added the default initialization op removal into the Tensorflow graph loader. Fix those.
- During testing, I figured out that different minor versions of Tensorflow/Protobuf are allowed to load tensors without extracting their shape (surprisingly, this has been an issue since the PPoPP tag on the repo!). The only affected test was the speech attention model.
- To make regression testing a little cleaner, add a flag to suppress warnings in the bash script, catamount/tests/run_tests.sh